### PR TITLE
feat: add Makefile template to nextjs-fullstack blueprint

### DIFF
--- a/src/scaffoldkit/blueprints/nextjs-fullstack/blueprint.yaml
+++ b/src/scaffoldkit/blueprints/nextjs-fullstack/blueprint.yaml
@@ -102,6 +102,9 @@ variables:
     default: true
 
 templates:
+  - source: Makefile.j2
+    target: Makefile
+
   - source: README.md.j2
     target: README.md
 

--- a/src/scaffoldkit/blueprints/nextjs-fullstack/templates/Makefile.j2
+++ b/src/scaffoldkit/blueprints/nextjs-fullstack/templates/Makefile.j2
@@ -1,0 +1,51 @@
+.PHONY: install{% if use_docker %} dev dev-docker docker-up docker-down{% else %} dev{% endif %} build test lint format ci clean help
+
+# Default target
+.DEFAULT_GOAL := help
+
+help: ## Show this help message
+	@echo 'Usage: make [target]'
+	@echo ''
+	@echo 'Available targets:'
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  %-15s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+install: ## Install dependencies
+	npm ci
+{% if db_provider != 'sqlite' %}	npx prisma generate
+{% endif %}
+{% if use_docker %}
+dev: ## Start development server (local)
+	npm run dev
+
+dev-docker: docker-up ## Start development server (Docker)
+
+docker-up: ## Start Docker development environment
+	docker compose -f docker-compose.dev.yml up --build
+
+docker-down: ## Stop Docker development environment
+	docker compose -f docker-compose.dev.yml down
+{% else %}
+dev: ## Start development server
+	npm run dev
+{% endif %}
+
+build: ## Build for production
+	npm run build
+
+test: ## Run tests
+	npm test
+
+lint: ## Run linting and type-checking
+	npm run lint
+	npm run type-check
+
+format: ## Format code
+	npm run format
+
+format-check: ## Check code formatting
+	npm run format:check
+
+ci: format-check lint test build ## Run all CI checks (format, lint, test, build)
+
+clean: ## Remove build artifacts and dependencies
+	rm -rf node_modules .next dist build coverage


### PR DESCRIPTION
Fixes #2

## Problem
nextjs-fullstack blueprint doesn't generate a Makefile, forcing developers to manually know and type npm commands.

## Solution
Added `Makefile.j2` Jinja2 template with standard development targets and conditional Docker support.

## Template Features

### Standard Targets (Always Included)
```makefile
make install       # npm ci + prisma generate
make dev           # Start development server
make build         # Build for production
make test          # Run tests
make lint          # ESLint + type-check
make format        # Prettier format
make format-check  # Check formatting
make ci            # Run all CI checks (format + lint + test + build)
make clean         # Remove build artifacts
make help          # Show available targets (default)
```

### Docker Targets (When `use_docker=true`)
```makefile
make dev-docker    # Start Docker dev environment (alias for docker-up)
make docker-up     # docker compose -f docker-compose.dev.yml up --build
make docker-down   # docker compose -f docker-compose.dev.yml down
```

When Docker is enabled, `make dev` becomes local-only and `make dev-docker` runs in Docker.

## Conditional Logic

**Prisma Generate:**
Only runs when `db_provider != 'sqlite'` (PostgreSQL/MySQL need schema generation)

**Docker Targets:**
Only included when `use_docker=true`

## Example Output

**Without Docker (`use_docker=false`):**
```makefile
dev: ## Start development server
\tnpm run dev
```

**With Docker (`use_docker=true`):**
```makefile
dev: ## Start development server (local)
\tnpm run dev

dev-docker: docker-up ## Start development server (Docker)

docker-up: ## Start Docker development environment
\tdocker compose -f docker-compose.dev.yml up --build

docker-down: ## Stop Docker development environment
\tdocker compose -f docker-compose.dev.yml down
```

## Integration

**Consistent with:**
- planforge Task 015 (Makefile template)
- agent-planforge templates/Makefile.template
- agent-dev-kit Makefile patterns

**Part of dogfooding improvements from ai-dashboard testrun.**

## Changes

- `src/scaffoldkit/blueprints/nextjs-fullstack/templates/Makefile.j2` (NEW, 1328 bytes)
- `src/scaffoldkit/blueprints/nextjs-fullstack/blueprint.yaml` (UPDATED - added Makefile.j2 to templates section)

## Testing

- Jinja2 template syntax valid
- Conditional logic tested manually
- CI will validate generation

## Benefits

**Developer Experience:**
✅ Single command for common tasks (`make dev`, `make ci`)
✅ Self-documenting (`make help` shows all targets)
✅ Consistent across projects
✅ No need to remember npm scripts

**CI/CD:**
✅ `make ci` runs all checks locally before push
✅ Prevents CI failures from format/lint issues
✅ Same command works in CI

**Docker Integration:**
✅ Seamless Docker dev environment
✅ `make dev-docker` for containerized dev
✅ Consistent environment across developers