### PR TITLE
feat: add Docker dev environment templates to nextjs-fullstack blueprint

### DIFF
--- a/src/scaffoldkit/blueprints/nextjs-fullstack/blueprint.yaml
+++ b/src/scaffoldkit/blueprints/nextjs-fullstack/blueprint.yaml
@@ -105,6 +105,14 @@ templates:
   - source: Makefile.j2
     target: Makefile
 
+  - source: docker-compose.dev.yml.j2
+    target: docker-compose.dev.yml
+    condition: use_docker
+
+  - source: Dockerfile.dev.j2
+    target: Dockerfile.dev
+    condition: use_docker
+
   - source: README.md.j2
     target: README.md
 
@@ -152,6 +160,10 @@ static_files:
 
   - source: .gitignore
     target: .gitignore
+
+  - source: .dockerignore
+    target: .dockerignore
+    condition: use_docker
 
 directories:
   - app/(public)

--- a/src/scaffoldkit/blueprints/nextjs-fullstack/static/.dockerignore
+++ b/src/scaffoldkit/blueprints/nextjs-fullstack/static/.dockerignore
@@ -1,0 +1,13 @@
+node_modules
+npm-debug.log
+.next
+.env
+.env.local
+.git
+.gitignore
+README.md
+.DS_Store
+dist
+build
+coverage
+*.log

--- a/src/scaffoldkit/blueprints/nextjs-fullstack/templates/Dockerfile.dev.j2
+++ b/src/scaffoldkit/blueprints/nextjs-fullstack/templates/Dockerfile.dev.j2
@@ -1,0 +1,26 @@
+FROM node:20-slim
+
+{% if db_provider != 'sqlite' %}# Install OpenSSL for Prisma
+RUN apt-get update && \
+    apt-get install -y openssl && \
+    rm -rf /var/lib/apt/lists/*
+
+{% endif %}WORKDIR /app
+
+# Copy package files
+COPY package*.json ./
+
+# Install dependencies
+RUN npm install
+
+# Copy application code
+COPY . .
+
+{% if db_provider != 'sqlite' %}# Generate Prisma client
+RUN npx prisma generate
+
+{% endif %}# Expose dev server port
+EXPOSE 3000
+
+# Start development server
+CMD ["npm", "run", "dev"]

--- a/src/scaffoldkit/blueprints/nextjs-fullstack/templates/docker-compose.dev.yml.j2
+++ b/src/scaffoldkit/blueprints/nextjs-fullstack/templates/docker-compose.dev.yml.j2
@@ -1,0 +1,58 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    volumes:
+      - ./:/app
+      - /app/node_modules
+    ports:
+      - "3000:3000"
+    environment:
+      - NODE_ENV=development
+{% if db_provider == 'postgresql' %}      - DATABASE_URL=postgresql://dev:dev@db:5432/{{ project_name }}_dev
+{% elif db_provider == 'mysql' %}      - DATABASE_URL=mysql://dev:dev@db:3306/{{ project_name }}_dev
+{% else %}      - DATABASE_URL=file:./dev.db
+{% endif %}{% if db_provider != 'sqlite' %}    depends_on:
+      db:
+        condition: service_healthy
+{% endif %}    command: npm run dev
+{% if db_provider == 'postgresql' %}
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: dev
+      POSTGRES_PASSWORD: dev
+      POSTGRES_DB: {{ project_name }}_dev
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U dev"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+{% elif db_provider == 'mysql' %}
+  db:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: {{ project_name }}_dev
+      MYSQL_USER: dev
+      MYSQL_PASSWORD: dev
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+{% endif %}
+{% if db_provider != 'sqlite' %}
+volumes:
+{% if db_provider == 'postgresql' %}  postgres_data:
+{% elif db_provider == 'mysql' %}  mysql_data:
+{% endif %}{% endif %}


### PR DESCRIPTION
Fixes #3

## Problem

nextjs-fullstack blueprint has `use_docker=true` variable but generates no Docker configuration files.

## Solution

Added Docker development environment templates with multi-database support:

- `docker-compose.dev.yml.j2` - Compose configuration with app + database services
- `Dockerfile.dev.j2` - Development container with Node 20 + Prisma
- `.dockerignore` - Standard Node.js ignores

All files are conditional on `use_docker=true`.

## Template Features

### docker-compose.dev.yml.j2

**App Service:**
- Volume mounts for hot reload (`./:/app`, `/app/node_modules`)
- Port 3000 exposed
- NODE_ENV=development
- Database-aware DATABASE_URL

**Database Service (Conditional):**

**PostgreSQL 16 (default):**
```yaml
db:
  image: postgres:16-alpine
  environment:
    POSTGRES_USER: dev
    POSTGRES_PASSWORD: dev
    POSTGRES_DB: {{ project_name }}_dev
  volumes:
    - postgres_data:/var/lib/postgresql/data
  healthcheck:
    test: ["CMD-SHELL", "pg_isready -U dev"]
```

**MySQL 8.0:**
```yaml
db:
  image: mysql:8.0
  environment:
    MYSQL_USER: dev
    MYSQL_PASSWORD: dev
    MYSQL_DATABASE: {{ project_name }}_dev
  volumes:
    - mysql_data:/var/lib/mysql
  healthcheck:
    test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
```

**SQLite:**
- No db service (file-based)
- `DATABASE_URL=file:./dev.db`

### Dockerfile.dev.j2

```dockerfile
FROM node:20-slim

# OpenSSL for Prisma (PostgreSQL/MySQL only)
RUN apt-get update && apt-get install -y openssl

WORKDIR /app
COPY package*.json ./
RUN npm install
COPY . .

# Prisma generate (PostgreSQL/MySQL only)
RUN npx prisma generate

EXPOSE 3000
CMD ["npm", "run", "dev"]
```

**Conditional:**
- OpenSSL only when `db_provider != 'sqlite'`
- Prisma generate only when `db_provider != 'sqlite'`

### .dockerignore

Standard Node.js ignores:
```
node_modules
.next
.env
.git
dist
build
coverage
*.log
```

## Conditional Logic

### When `use_docker=false`
- No Docker files generated
- Clean output

### When `use_docker=true` + `db_provider='postgresql'` (default)
- Full Docker stack with PostgreSQL 16
- Health checks
- Named volumes for persistence

### When `use_docker=true` + `db_provider='mysql'`
- MySQL 8.0 instead of PostgreSQL
- MySQL-specific health check

### When `use_docker=true` + `db_provider='sqlite'`
- No database container
- File-based DATABASE_URL
- No OpenSSL/Prisma in Dockerfile

## Integration

**Consistent with:**
- planforge Task 016 (Docker Dev Environment)
- agent-planforge templates
- Makefile.j2 Docker targets (`make dev-docker`, `docker-up`, `docker-down`)

**Generated Makefile already supports:**
```makefile
dev-docker: docker-up

docker-up:
\tdocker compose -f docker-compose.dev.yml up --build

docker-down:
\tdocker compose -f docker-compose.dev.yml down
```

## Usage

```bash
# Start Docker dev environment
docker compose -f docker-compose.dev.yml up --build

# Or using Makefile
make dev-docker

# Stop environment
make docker-down
```

## Changes

- `src/scaffoldkit/blueprints/nextjs-fullstack/templates/docker-compose.dev.yml.j2` (NEW, 1592 bytes)
- `src/scaffoldkit/blueprints/nextjs-fullstack/templates/Dockerfile.dev.j2` (NEW, 500 bytes)
- `src/scaffoldkit/blueprints/nextjs-fullstack/static/.dockerignore` (NEW, 111 bytes)
- `src/scaffoldkit/blueprints/nextjs-fullstack/blueprint.yaml` (UPDATED - added 3 conditional templates)

## Testing

- Jinja2 template syntax valid
- Multi-database logic tested
- CI will validate generation

## Benefits

**Developer Experience:**
✅ Consistent environment across team (Node 20 pinned)
✅ No "works on my machine" issues
✅ Database included (no manual setup)
✅ Hot reload works in Docker

**Multi-Database Support:**
✅ PostgreSQL 16 (production-like)
✅ MySQL 8.0 support
✅ SQLite (lightweight, no container needed)

**Production Parity:**
✅ Pinned Node version (20-slim)
✅ OpenSSL for Prisma binary compatibility
✅ Health checks prevent race conditions

**Integration:**
✅ Works with generated Makefile
✅ Prisma generate automatic
✅ Named volumes for data persistence