### PR TITLE
feat: run npm install after generation to create package-lock.json

### DIFF
--- a/src/scaffoldkit/cli.py
+++ b/src/scaffoldkit/cli.py
@@ -40,6 +40,9 @@ def new(
     overwrite: Annotated[
         bool, typer.Option("--overwrite", help="Overwrite existing files")
     ] = False,
+    no_install: Annotated[
+        bool, typer.Option("--no-install", help="Skip npm install after generation")
+    ] = False,
     blueprints_dir: Annotated[
         Path | None, typer.Option("--blueprints-dir", "-b", help="Custom blueprints dir")
     ] = None,
@@ -95,6 +98,24 @@ def new(
 
     if not gen_result.success:
         raise typer.Exit(1)
+
+    # Run npm install if package.json exists and not skipped
+    if not dry_run and not no_install and (target / "package.json").exists():
+        import subprocess
+        
+        console.print("\n[bold cyan]Running npm install...[/bold cyan]")
+        try:
+            subprocess.run(
+                ["npm", "install"],
+                cwd=target,
+                check=True,
+                capture_output=False,
+            )
+            console.print("[green]✓ npm install completed[/green]")
+        except subprocess.CalledProcessError as e:
+            console.print(f"[yellow]Warning: npm install failed with exit code {e.returncode}[/yellow]")
+        except FileNotFoundError:
+            console.print("[yellow]Warning: npm not found in PATH, skipping install[/yellow]")
 
 
 @app.command(name="init-blueprint")


### PR DESCRIPTION
Fixes #5

## Problem

ScaffoldKit generates no package-lock.json after blueprint generation. Without a lock file:
- Each developer/agent gets different dependency versions
- "Works on my machine" issues
- Inconsistent CI builds
- Security vulnerabilities from unlocked dependencies

## Solution

Automatically run `npm install` after successful generation to create package-lock.json.

**Features:**
- `--no-install` flag to skip (default: install enabled)
- Only runs if package.json exists
- Safe error handling (warnings, not failures)
- Skipped automatically in dry-run mode

## Implementation

### CLI Changes (cli.py)

**New Flag:**
```python
no_install: Annotated[
    bool, typer.Option("--no-install", help="Skip npm install after generation")
] = False
```

**Post-Generation Hook:**
```python
# After successful generation:
if not dry_run and not no_install and (target / "package.json").exists():
    subprocess.run(["npm", "install"], cwd=target, check=True)
```

## Behavior

### Default (npm install runs)

```bash
$ scaffoldkit new nextjs-fullstack my-app

✓ Generated 15 files
✓ Created 8 directories

Running npm install...
added 123 packages in 5s
✓ npm install completed
```

### Skipped with flag

```bash
$ scaffoldkit new nextjs-fullstack my-app --no-install

✓ Generated 15 files
✓ Created 8 directories

(no npm install)
```

### Skipped in dry-run

```bash
$ scaffoldkit new nextjs-fullstack my-app --dry-run

Preview: would generate 15 files...
(no npm install, no files written)
```

## Error Handling

**npm not found:**
```
Warning: npm not found in PATH, skipping install
```

**npm install fails:**
```
Warning: npm install failed with exit code 1
```

Both show warnings (yellow) but don't fail generation - allows manual install later.

## Benefits

**Reproducibility:**
✅ Same dependency versions across all developers  
✅ CI matches local builds exactly  
✅ Lock file committed to repo  

**Security:**
✅ Locked dependency versions prevent supply chain attacks  
✅ npm audit works (requires lock file)  
✅ Renovate/Dependabot can track exact versions  

**Developer Experience:**
✅ One command to fully working project  
✅ No manual `npm install` step  
✅ Immediate testing (`npm test`, `npm run dev`)  

**CI/CD:**
✅ `npm ci` works immediately (requires package-lock.json)  
✅ Faster installs (ci vs install)  
✅ Deterministic builds  

## Example Workflow

**Before (manual):**
```bash
scaffoldkit new nextjs-fullstack my-app
cd my-app
npm install  # Manual step, easy to forget
npm test
```

**After (automatic):**
```bash
scaffoldkit new nextjs-fullstack my-app
cd my-app
npm test  # Works immediately!
```

## Generated Files

```
my-app/
├── package.json         # Generated by blueprint
├── package-lock.json    # Generated by npm install ✅
├── node_modules/        # Generated by npm install ✅
└── ...
```

## Changes

- **src/scaffoldkit/cli.py** (UPDATED):
  - Added `no_install` parameter
  - Post-generation npm install hook
  - Error handling for npm not found / install failure

## Integration

**Consistent with:**
- planforge Task 019 (Lock File Generation)
- agent-planforge `--install` / `--no-install` pattern

## Testing

✅ Tested with nextjs-fullstack blueprint  
✅ Verified package-lock.json creation  
✅ Tested `--no-install` flag  
✅ Tested error handling (npm not found)  

## Note on Whitespace Handling

Ice suggested adding `trim_blocks`/`lstrip_blocks` to fix whitespace issues. **This is already present** in renderer.py since the initial commit:

```python
def create_jinja_env(template_dir: Path) -> Environment:
    return Environment(
        trim_blocks=True,      # ✅ Already there
        lstrip_blocks=True,    # ✅ Already there
        # ...
    )
```

No changes needed - whitespace handling is already correct!