### PR TITLE
fix(meta): correct repository URLs in pyproject.toml and docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to ScaffoldKit! This document explai
 
 ```bash
 # Clone the repository
-git clone <repo-url>
+git clone https://github.com/LanNguyenSi/scaffoldkit.git
 cd scaffoldkit
 
 # Create virtual environment and install with dev dependencies

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ No Python installation required. Choose whichever method fits your setup.
 ### Option A: One-line installer (recommended)
 
 ```bash
-git clone <repo-url> scaffoldkit && cd scaffoldkit
+git clone https://github.com/LanNguyenSi/scaffoldkit.git scaffoldkit && cd scaffoldkit
 ./install.sh
 ```
 
@@ -31,7 +31,7 @@ This installs [uv](https://docs.astral.sh/uv/) (if not present), which then hand
 ### Option B: Docker (no Python needed at all)
 
 ```bash
-git clone <repo-url> scaffoldkit && cd scaffoldkit
+git clone https://github.com/LanNguyenSi/scaffoldkit.git scaffoldkit && cd scaffoldkit
 ./install.sh --docker
 ```
 
@@ -64,7 +64,7 @@ python3 -m pip install --user pipx
 python3 -m pipx ensurepath
 
 # Install scaffoldkit
-git clone <repo-url> scaffoldkit
+git clone https://github.com/LanNguyenSi/scaffoldkit.git scaffoldkit
 cd scaffoldkit
 pipx install .
 
@@ -82,7 +82,7 @@ scaffoldkit --help
 
 ```bash
 # Clone repository
-git clone <repo-url> scaffoldkit
+git clone https://github.com/LanNguyenSi/scaffoldkit.git scaffoldkit
 cd scaffoldkit
 
 # Create virtual environment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,9 +33,9 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/scaffoldkit/scaffoldkit"
-Repository = "https://github.com/scaffoldkit/scaffoldkit"
-Issues = "https://github.com/scaffoldkit/scaffoldkit/issues"
+Homepage = "https://github.com/LanNguyenSi/scaffoldkit"
+Repository = "https://github.com/LanNguyenSi/scaffoldkit"
+Issues = "https://github.com/LanNguyenSi/scaffoldkit/issues"
 
 [project.scripts]
 scaffoldkit = "scaffoldkit.cli:app"


### PR DESCRIPTION
## Summary

`pyproject.toml` `[project.urls]` pointed at `github.com/scaffoldkit/scaffoldkit`, an org that does not exist; actual remote is `LanNguyenSi/scaffoldkit`. PyPI renders these into the project sidebar, so they would have shipped broken on v0.1.0.

Also replaces `git clone <repo-url>` placeholders in README install options (A, B, D, E) and CONTRIBUTING with the real clone URL so the snippets are copy-pasteable. Blueprint `.j2` templates keep `<repo-url>` intentionally — those render into generated projects for the end user to fill in.

## Changes

- `pyproject.toml`: 3 URLs (Homepage / Repository / Issues) → `LanNguyenSi/scaffoldkit`
- `README.md`: 4 clone snippets → real URL
- `CONTRIBUTING.md`: 1 clone snippet → real URL

## Test plan

- [x] `uv run pytest -q` → 259 passed
- [x] `uv run ruff check src/ tests/` → clean
- [x] `uv run ruff format --check src/ tests/` → clean
- [x] `grep -rn "scaffoldkit/scaffoldkit\|<repo-url>" .` → only template `.j2` placeholders remain (intentional)
- [x] `git remote -v` matches the new URL

Closes the PyPI URL release-blocker for v0.1.0.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>