### PR TITLE
feat(cli): add --version/-V flag

### DIFF
--- a/src/scaffoldkit/cli.py
+++ b/src/scaffoldkit/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import subprocess
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import Annotated, Any
 
@@ -36,6 +37,35 @@ app = typer.Typer(
     no_args_is_help=True,
 )
 console = Console()
+
+
+def _resolve_version() -> str:
+    try:
+        return version("scaffoldkit")
+    except PackageNotFoundError:
+        return "0.0.0+unknown"
+
+
+def _version_callback(value: bool) -> None:
+    if value:
+        typer.echo(f"scaffoldkit {_resolve_version()}")
+        raise typer.Exit(0)
+
+
+@app.callback()
+def _main(
+    _version: Annotated[
+        bool,
+        typer.Option(
+            "--version",
+            "-V",
+            callback=_version_callback,
+            is_eager=True,
+            help="Show the scaffoldkit version and exit.",
+        ),
+    ] = False,
+) -> None:
+    """AI-aided project scaffolding tool."""
 
 
 def _run_npm_install(target: Path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,12 +1,25 @@
 """Tests for CLI commands."""
 
 import json
+from importlib.metadata import version
 
 from typer.testing import CliRunner
 
 from scaffoldkit.cli import app
 
 runner = CliRunner()
+
+
+class TestVersionFlag:
+    def test_long_flag_prints_package_version(self):
+        result = runner.invoke(app, ["--version"])
+        assert result.exit_code == 0
+        assert result.output.strip() == f"scaffoldkit {version('scaffoldkit')}"
+
+    def test_short_flag_prints_package_version(self):
+        result = runner.invoke(app, ["-V"])
+        assert result.exit_code == 0
+        assert result.output.strip() == f"scaffoldkit {version('scaffoldkit')}"
 
 
 class TestListCommand:


### PR DESCRIPTION
## Summary

Adds a standard `--version/-V` flag to the `scaffoldkit` CLI. Missing today (`scaffoldkit --version` errors with `No such option`).

Reads `importlib.metadata.version("scaffoldkit")` so the output stays in sync with `pyproject.toml` across version bumps.

## Changes

- `src/scaffoldkit/cli.py`: new `@app.callback()` with `--version/-V` option using `is_eager=True` so the flag short-circuits before subcommand routing
- `tests/test_cli.py`: 2 tests covering `--version` and `-V`, asserting equality against `importlib.metadata.version` (won't drift on next release)

## Verification

- 261 tests pass (`uv run pytest`)
- `ruff check`, `ruff format --check`, `mypy` all clean
- Dogfood: `uv run scaffoldkit --version` → `scaffoldkit 0.1.0`
- `no_args_is_help` behavior preserved: bare `scaffoldkit` still shows help with all 4 subcommands
- All 4 subcommands (`new`, `from-planforge`, `init-blueprint`, `list`) still register and run

## Test plan

- [x] `scaffoldkit --version` prints `scaffoldkit <pyproject_version>` and exits 0
- [x] `scaffoldkit -V` works identically
- [x] Existing commands unaffected
- [x] `scaffoldkit` (no args) still shows help (no_args_is_help intact)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>