### PR TITLE
ci: add release workflow on v* tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+jobs:
+  ci:
+    name: CI
+    uses: ./.github/workflows/ci.yml
+    permissions:
+      contents: read
+
+  release:
+    name: GitHub Release
+    needs: ci
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify pyproject version matches tag
+        run: |
+          pyproject_version=$(grep -E '^version = ' pyproject.toml | head -1 | sed -E 's/version = "(.+)"/\1/')
+          if [ "$pyproject_version" != "${{ steps.version.outputs.version }}" ]; then
+            echo "::error::Tag version (${{ steps.version.outputs.version }}) does not match pyproject.toml version ($pyproject_version)"
+            exit 1
+          fi
+
+      - name: Extract changelog for this version
+        run: |
+          awk '/^## \[${{ steps.version.outputs.version }}\]/{found=1; next} /^## \[/{found=0} found' CHANGELOG.md > release_notes.md
+          if [ ! -s release_notes.md ]; then
+            echo "::error::No CHANGELOG section found for version ${{ steps.version.outputs.version }}"
+            exit 1
+          fi
+          echo "Release notes extracted for v${{ steps.version.outputs.version }}"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Build distribution
+        run: uv build
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: v${{ steps.version.outputs.version }}
+          body_path: release_notes.md
+          generate_release_notes: false
+          files: |
+            dist/*.whl
+            dist/*.tar.gz


### PR DESCRIPTION
## Summary

Adds the tag-driven GitHub Release workflow that the sibling repos already have (codebase-oracle, project-forge, agent-planforge, etc.). Closes the last gap before tagging `v0.1.0`.

## Pattern

1. Trigger on `push` of any `v*` tag.
2. Re-run the existing CI workflow via `workflow_call` so a release can never publish if tests/lint/typecheck/build fail.
3. Extract the matching `## [<version>]` section from `CHANGELOG.md` via `awk`.
4. Create the GitHub Release with `softprops/action-gh-release@v2`.

## scaffoldkit-specific additions

- **Wheel + sdist as release assets.** `uv build` runs and `dist/*.whl` + `dist/*.tar.gz` are attached to the release. Consumers can grab artifacts straight from the GitHub Releases page without going through PyPI.
- **Tag vs pyproject guard.** Job exits 1 if the tag (e.g. `v0.1.0`) does not match `version` in `pyproject.toml`. Catches the "forgot to bump pyproject" footgun.
- **Empty-CHANGELOG guard.** Job exits 1 if the awk extraction produces an empty `release_notes.md`.

## Changes

- `.github/workflows/ci.yml`: add `workflow_call:` to the existing trigger list (push/pull_request unchanged).
- `.github/workflows/release.yml`: new file.

## Verification (locally)

- [x] `awk` against current `CHANGELOG.md` with `version=0.1.0` extracts 70 lines starting at "First public release." through the link references — no bleed into `[Unreleased]`.
- [x] Version-grep on `pyproject.toml` returns `0.1.0`.
- [x] `uv build` produces `dist/scaffoldkit-0.1.0-py3-none-any.whl` and `dist/scaffoldkit-0.1.0.tar.gz`.
- [x] Permissions: `contents: write` only at the workflow level for the release job; the reusable CI call is downgraded to `contents: read`.

## After merge

Tag and push:

```bash
git tag v0.1.0
git push origin v0.1.0
```

The workflow should pick up the tag, run CI, and create the release at `github.com/LanNguyenSi/scaffoldkit/releases/tag/v0.1.0` with the CHANGELOG body and both build artifacts attached.

## Follow-ups (separate tasks)

- The `symfony-nextjs` blueprint emits ~20 duplicate-filename warnings during `uv build` (pre-existing on master, not introduced here). The wheel still builds, but worth a follow-up.
- PyPI publishing not added — sibling repos don't publish either; can revisit later.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>