### PR TITLE
docs: README 60s hook + restructure into docs/

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,417 +1,69 @@
 # ScaffoldKit
 
-AI-aided project scaffolding tool with declarative blueprints.
+AI-aided project scaffolding from declarative blueprints.
 
-## Vision
+ScaffoldKit generates complete project skeletons (source layout, docs, ways-of-working, ADRs, page templates, AI context files) from a folder of YAML blueprints plus Jinja2 templates. It is the scaffolding engine behind [project-forge](https://github.com/LanNguyenSi/project-forge) and consumes the `scaffoldkit-input.json` export from [agent-planforge](https://github.com/LanNguyenSi/agent-planforge), so blueprints written here flow straight into both downstream tools.
 
-ScaffoldKit generates complete project skeletons from declarative blueprints - including project structure, documentation, ways-of-working guides, page templates, design references, and AI context files for downstream agent workflows.
+## Try it in 60 seconds
+
+```bash
+git clone https://github.com/LanNguyenSi/scaffoldkit.git
+cd scaffoldkit
+./install.sh
+
+# generate a CLI tool skeleton from the cli-tool blueprint
+scaffoldkit new cli-tool \
+  --target ./hello-cli \
+  --non-interactive --yes \
+  --var project_name=hello-cli \
+  --var display_name="Hello CLI" \
+  --var description="A demo CLI"
+```
+
+Don't want Python on your host? Use `./install.sh --docker` instead. See [docs/cli.md](docs/cli.md#installation) for every install path.
+
+## What you get
+
+```
+Generation completed successfully!
+
+Files created (9):
+  README.md
+  pyproject.toml
+  .github/workflows/ci.yml
+  docs/architecture.md
+  docs/ways-of-working.md
+  docs/adrs/0001-architecture.md
+  AI_CONTEXT.md
+  .editorconfig
+  .gitignore
+
+Directories (6):
+  hello-cli/
+  hello-cli/src
+  hello-cli/src/commands
+  hello-cli/src/config
+  hello-cli/tests
+  hello-cli/docs/adrs
+```
+
+`AI_CONTEXT.md` and the `docs/` set are the point: every blueprint ships ways-of-working, an architecture doc, and an ADR seed so a downstream Claude Code or Cursor session has real context from minute one. Run `scaffoldkit list` to see all 13 blueprints.
+
+## Next steps
+
+| If you want to... | Read |
+|------|------|
+| See every blueprint, its variables, and the YAML/Jinja format | [docs/blueprints.md](docs/blueprints.md) |
+| Pipe an agent-planforge export into `scaffoldkit from-planforge` | [docs/planforge-integration.md](docs/planforge-integration.md) |
+| Understand how generation works (loader, renderer, filesystem) | [docs/architecture.md](docs/architecture.md) |
+| Full CLI reference (`new`, `from-planforge`, `init-blueprint`, `list`) | [docs/cli.md](docs/cli.md) |
 
 ## Used by
 
-ScaffoldKit is used in production as the scaffolding engine for two sibling tools in the Project OS pipeline:
+- [project-forge](https://github.com/LanNguyenSi/project-forge), end-to-end project bootstrapper that invokes ScaffoldKit for blueprint generation.
+- [agent-planforge](https://github.com/LanNguyenSi/agent-planforge), planning tool whose `scaffoldkit-input.json` export feeds directly into `scaffoldkit from-planforge`.
 
-- **[project-forge](https://github.com/LanNguyenSi/project-forge)** — end-to-end project bootstrapper that invokes ScaffoldKit for blueprint generation.
-- **[agent-planforge](https://github.com/LanNguyenSi/agent-planforge)** — planning tool whose `scaffoldkit-input.json` export feeds directly into `scaffoldkit from-planforge`.
-
-Both depend on this repo in production; changes to blueprint contracts here ripple into those consumers.
-
-## Installation
-
-No Python installation required. Choose whichever method fits your setup.
-
-### Option A: One-line installer (recommended)
-
-```bash
-git clone https://github.com/LanNguyenSi/scaffoldkit.git scaffoldkit && cd scaffoldkit
-./install.sh
-```
-
-This installs [uv](https://docs.astral.sh/uv/) (if not present), which then handles Python and all dependencies automatically. The `scaffoldkit` command is placed in `~/.local/bin`.
-
-### Option B: Docker (no Python needed at all)
-
-```bash
-git clone https://github.com/LanNguyenSi/scaffoldkit.git scaffoldkit && cd scaffoldkit
-./install.sh --docker
-```
-
-This builds a Docker image and installs a thin wrapper. Only Docker and Bash are required.
-
-Or use the wrapper script directly:
-
-```bash
-# Build once
-docker build -t scaffoldkit:latest .
-
-# Run via wrapper
-./scaffoldkit-docker --output ./my-projects -- new
-./scaffoldkit-docker -- list
-```
-
-### Option C: Makefile shortcuts
-
-```bash
-make install          # same as ./install.sh
-make install-docker   # same as ./install.sh --docker
-make dev              # create .venv with dev dependencies
-```
-
-### Option D: pipx (isolated installation)
-
-```bash
-# Install pipx if not already installed
-python3 -m pip install --user pipx
-python3 -m pipx ensurepath
-
-# Install scaffoldkit
-git clone https://github.com/LanNguyenSi/scaffoldkit.git scaffoldkit
-cd scaffoldkit
-pipx install .
-
-# Now available globally
-scaffoldkit --help
-```
-
-**Benefits:**
-- ✅ Isolated from system Python
-- ✅ No virtualenv activation needed
-- ✅ Global command available
-- ✅ Easy to uninstall: `pipx uninstall scaffoldkit`
-
-### Option E: venv (development setup)
-
-```bash
-# Clone repository
-git clone https://github.com/LanNguyenSi/scaffoldkit.git scaffoldkit
-cd scaffoldkit
-
-# Create virtual environment
-python3 -m venv .venv
-source .venv/bin/activate  # On Windows: .venv\Scripts\activate
-
-# Install with dev dependencies
-pip install -e ".[dev]"
-
-# Run scaffoldkit
-scaffoldkit --help
-```
-
-**Use when:**
-- Contributing to scaffoldkit
-- Need dev dependencies (ruff, mypy, pytest)
-- Want editable installation
-
-**Note:** If you get "externally-managed-environment" error on Debian/Ubuntu:
-```bash
-# Use venv instead of system pip
-python3 -m venv .venv
-source .venv/bin/activate
-pip install -e .
-```
-
-### Option F: Manual (if you already have Python 3.11+)
-
-```bash
-pip install .
-# or for development:
-uv venv .venv --python 3.12
-source .venv/bin/activate
-uv pip install -e ".[dev]"
-```
-
-## Usage
-
-### Interactive Mode
-
-```bash
-scaffoldkit new
-```
-
-This launches the interactive TUI:
-
-1. **Select a blueprint:** Choose from available blueprints
-2. **Configure variables:** Answer prompts for project name, stack, features, etc.
-3. **Choose target directory:** Where to generate the project
-4. **Review and confirm:** See a summary before generation
-5. **Generate:** Files are created and a summary is printed
-
-### Direct Mode
-
-```bash
-scaffoldkit new saas-dashboard --target ./my-project
-```
-
-### Non-Interactive Mode
-
-You can scaffold without the TUI by passing variables explicitly:
-
-```bash
-scaffoldkit new symfony-backend \
-  --target ./my-symfony-app \
-  --non-interactive \
-  --var project_name=my-symfony-app \
-  --var display_name="My Symfony App" \
-  --var description="A Symfony-based API backend" \
-  --var php_version=8.3 \
-  --var symfony_version=7.2 \
-  --var api_style=api-platform \
-  --var database=postgresql \
-  --var use_ddd=true \
-  --var use_cqrs=true \
-  --var use_auth=false \
-  --var use_docker=true \
-  --var use_ci=true \
-  --var use_rabbitmq=false \
-  --var use_redis=false \
-  --var test_strategy=phpunit-only \
-  --var ai_context=true
-```
-
-Notes:
-
-- `--non-interactive` fills in omitted values from blueprint defaults
-- required variables without defaults still fail fast
-- conditional variables are skipped automatically when their parent flag is disabled
-- boolean values accept `true` / `false`, `yes` / `no`, and `1` / `0`
-
-### From agent-planforge
-
-If you already have a `scaffoldkit-input.json` export from `agent-planforge`, generate directly from it:
-
-```bash
-scaffoldkit from-planforge ./scaffoldkit-input.json --target ./my-project
-```
-
-This uses the recommended blueprint from the export and applies planforge-provided variable hints before generation.
-
-### Options
-
-```bash
-scaffoldkit new [BLUEPRINT] [OPTIONS]
-
-Options:
-  -t, --target PATH        Target directory
-  -n, --dry-run            Preview without writing files
-  --overwrite              Overwrite existing files
-  --var KEY=VALUE          Set blueprint variable (repeatable)
-  --non-interactive        Use provided values and blueprint defaults without prompting
-  -y, --yes                Skip the confirmation prompt
-  -b, --blueprints-dir     Custom blueprints directory
-```
-
-### List Blueprints
-
-```bash
-scaffoldkit list
-```
-
-Current notable blueprints include `fastapi-backend`, `django-drf`, `rest-api`, `express-api`, `nextjs-fullstack`, `nextjs-frontend`, `symfony-backend`, `symfony-nextjs`, `springboot-backend`, `static-site`, and `cli-tool`.
-
-### Docker Usage
-
-```bash
-# Interactive
-scaffoldkit-docker --output ./projects -- new
-
-# List blueprints
-scaffoldkit-docker -- list
-
-# Show docker command without running
-scaffoldkit-docker --print -- new saas-dashboard
-
-# Rebuild image before running
-scaffoldkit-docker --build --output ./projects -- new
-```
-
-## Example Workflow
-
-```bash
-$ scaffoldkit new
-
-? Select a blueprint: SaaS Dashboard (saas-dashboard) - Full-stack SaaS dashboard
-? project_name: my-saas-app
-? display_name: My SaaS App
-? description: A modern SaaS dashboard
-? stack: nextjs-fullstack
-? architecture_style: monorepo
-? use_ddd: No
-? use_auth: Yes
-? use_docker: Yes
-? use_ci: Yes
-? test_strategy: unit-and-integration
-? design_style: minimal-clean
-? ai_context: Yes
-? Target directory: ./my-saas-app
-
-? Proceed with generation? Yes
-
-Generation completed successfully!
-
-Files created (10):
-  ✓ README.md
-  ✓ AI_CONTEXT.md
-  ✓ docs/architecture.md
-  ✓ docs/ways-of-working.md
-  ✓ docs/adrs/0001-architecture.md
-  ✓ docs/page-templates/dashboard-page.md
-  ✓ docs/page-templates/detail-page.md
-  ✓ docs/page-templates/settings-page.md
-  ✓ .gitignore
-  ✓ .editorconfig
-
-Directories (6):
-  apps/web
-  apps/api
-  packages/ui
-  packages/shared
-```
-
-## Architecture
-
-Three-layer architecture:
-
-```
-┌─────────────────────────────────┐
-│  TUI / CLI Layer                │  Interactive prompts, display
-│  (cli.py, tui.py)               │
-├─────────────────────────────────┤
-│  Generator / Rendering Layer    │  Template rendering, file I/O
-│  (generator.py, renderer.py,    │
-│   filesystem.py)                │
-├─────────────────────────────────┤
-│  Blueprint / Data Layer         │  Models, loading, validation
-│  (models.py, blueprint_loader.py│
-│   validators.py)                │
-└─────────────────────────────────┘
-```
-
-### Design Principles
-
-- **Declarative over hard-coded:** Blueprints are YAML, templates are Jinja2
-- **Extensible over perfect:** Add a new blueprint by adding a folder
-- **Locally runnable:** No external services required
-- **AI-friendly by design:** Generates context files for AI agents
-
-## Project Structure
-
-```
-scaffoldkit/
-├── install.sh             # One-line installer (uv or Docker)
-├── Makefile               # Build, test, install shortcuts
-├── Dockerfile             # Container build
-├── scaffoldkit-docker     # Docker wrapper script
-├── pyproject.toml
-├── src/
-│   └── scaffoldkit/
-│       ├── cli.py              # Typer CLI entry point
-│       ├── tui.py              # Interactive prompts (questionary + rich)
-│       ├── generator.py        # Core generation engine
-│       ├── blueprint_loader.py # Blueprint discovery and parsing
-│       ├── renderer.py         # Jinja2 template rendering
-│       ├── models.py           # Pydantic data models
-│       ├── validators.py       # Input validation
-│       └── filesystem.py       # File system operations
-├── blueprints/
-│   └── saas-dashboard/
-│       ├── blueprint.yaml      # Blueprint definition
-│       ├── templates/          # Jinja2 templates
-│       └── static/             # Static files (copied as-is)
-├── tests/
-├── .github/workflows/ci.yml
-├── CONTRIBUTING.md
-└── LICENSE
-```
-
-## Technologies
-
-| Component | Technology |
-|-----------|-----------|
-| Language | Python 3.11+ |
-| CLI | [Typer](https://typer.tiangolo.com/) |
-| TUI Prompts | [questionary](https://github.com/tmbo/questionary) + [Rich](https://rich.readthedocs.io/) |
-| Templating | [Jinja2](https://jinja.palletsprojects.com/) |
-| YAML | [PyYAML](https://pyyaml.org/) |
-| Models | [Pydantic](https://docs.pydantic.dev/) |
-| Packaging | [Hatch](https://hatch.pypa.io/) + [uv](https://docs.astral.sh/uv/) |
-| Container | Docker (optional) |
-
-## Blueprint Concept
-
-A blueprint is a folder containing:
-
-```
-blueprints/<name>/
-├── blueprint.yaml    # Definition: metadata, variables, file mappings
-├── templates/        # Jinja2 templates (rendered with variables)
-└── static/           # Static files (copied as-is)
-```
-
-### blueprint.yaml Structure
-
-```yaml
-name: my-blueprint
-display_name: "My Blueprint"
-description: "What this blueprint generates"
-version: "1.0.0"
-stack: "nextjs"
-
-variables:
-  - name: project_name
-    description: "Project slug"
-    type: string          # string | boolean | choice
-    default: "my-project"
-    required: true
-
-  - name: use_docker
-    type: boolean
-    default: true
-
-  - name: stack
-    type: choice
-    choices: ["nextjs", "remix", "astro"]
-    default: "nextjs"
-
-templates:
-  - source: README.md.j2        # Path inside templates/
-    target: README.md            # Path in generated project
-    condition: null              # Optional: variable that must be truthy
-
-static_files:
-  - source: .gitignore
-    target: .gitignore
-
-directories:
-  - src
-  - docs
-```
-
-### Template Variables
-
-Templates use Jinja2 syntax. All user variables plus blueprint metadata are available:
-
-```jinja
-# {{ display_name }}
-
-Stack: {{ stack }}
-{% if use_auth %}
-Authentication is enabled.
-{% endif %}
-```
-
-## Adding a New Blueprint
-
-1. Create a folder under `blueprints/`:
-   ```
-   blueprints/my-new-blueprint/
-   ```
-
-2. Create `blueprint.yaml` with metadata, variables, and file mappings.
-
-3. Add Jinja2 templates in `templates/`.
-
-4. Add static files in `static/` (optional).
-
-5. Run `scaffoldkit list` to verify it's discovered.
+Both depend on this repo in production. Changes to blueprint contracts here ripple into those consumers.
 
 ## Development
 
@@ -421,53 +73,20 @@ source .venv/bin/activate
 make check            # run lint + typecheck + test
 ```
 
-Or manually:
+Or directly:
 
 ```bash
-pytest                                            # tests
-pytest --cov=scaffoldkit --cov-report=term-missing # coverage
-ruff check src/ tests/                            # lint
-ruff format src/ tests/                           # format
-mypy src/scaffoldkit/                             # type check
+pytest                                              # tests
+pytest --cov=scaffoldkit --cov-report=term-missing  # coverage
+ruff check src/ tests/                              # lint
+ruff format src/ tests/                             # format
+mypy src/scaffoldkit/                               # type check
 ```
 
-### Test Suite
+CI runs lint, mypy strict, pytest on Python 3.11/3.12/3.13, and a build+install verification on every push and PR to `main`.
 
-78 tests covering:
-
-- **Models**: data model construction and validation
-- **Blueprint loading**: discovery, parsing, error handling
-- **Validators**: required fields, type checks, choice validation
-- **Renderer**: string rendering, template rendering, missing variable errors
-- **Filesystem**: directory creation, file writing, copy, overwrite protection
-- **Generator**: full pipeline, dry-run, conditions, overwrite, static files
-- **CLI**: command help, blueprint listing, error paths
-- **Integration**: end-to-end generation with all stack/style/feature variations
-
-### CI Pipeline
-
-GitHub Actions runs on every push and PR to `main`:
-
-- **Lint** - ruff check + format verification
-- **Type Check** - mypy strict mode
-- **Test** - pytest on Python 3.11, 3.12, 3.13
-- **Build** - package build + install verification
-
-## Changelog
-
-See [CHANGELOG.md](CHANGELOG.md) for release history.
-
-## Contributing
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, coding standards, and PR process.
-
-## Assumptions
-
-- Python 3.11+ (managed automatically via uv if using the installer)
-- Blueprints live alongside the source code (no remote registry yet)
-- Single-user local execution (no concurrency handling)
-- Blueprint variables are flat (no nested objects)
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, coding standards, and PR process. Release history lives in [CHANGELOG.md](CHANGELOG.md).
 
 ## License
 
-MIT - see [LICENSE](LICENSE)
+MIT, see [LICENSE](LICENSE).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,129 @@
+# Architecture
+
+ScaffoldKit is three layers stacked top to bottom: a Typer CLI / questionary TUI on top, a generation engine in the middle, and a YAML/Pydantic blueprint layer at the bottom. The engine is pure Python with no daemons, no remote services, and no shared state across runs.
+
+## Layer diagram
+
+```
+┌─────────────────────────────────┐
+│  TUI / CLI Layer                │  Interactive prompts, display
+│  (cli.py, tui.py)               │
+├─────────────────────────────────┤
+│  Generator / Rendering Layer    │  Template rendering, file I/O
+│  (generator.py, renderer.py,    │
+│   filesystem.py)                │
+├─────────────────────────────────┤
+│  Blueprint / Data Layer         │  Models, loading, validation
+│  (models.py, blueprint_loader.py│
+│   validators.py)                │
+└─────────────────────────────────┘
+```
+
+## Module map
+
+| Module | Responsibility |
+|--------|----------------|
+| `cli.py` | Typer entry point. Owns the four subcommands (`new`, `from-planforge`, `init-blueprint`, `list`) and the post-generate `npm install` hook. |
+| `tui.py` | Interactive prompts (questionary + Rich). Blueprint picker, variable collection, target-dir prompt, confirmation summary, post-generate result printer. |
+| `generator.py` | Orchestrates a generation run: validates variables, prunes inactive ones, builds the Jinja context (including derived `is_*` flags), iterates templates and static files, creates declared directories, returns a `GenerationResult`. |
+| `renderer.py` | Wraps Jinja2: env construction, string rendering for inline values, template rendering from disk, raises with file context on missing variables. |
+| `filesystem.py` | All file I/O: `ensure_directory`, `write_file`, `copy_file`. Honours `dry_run` and `overwrite` from the generation context. |
+| `models.py` | Pydantic models: `Blueprint`, `BlueprintVariable`, `VariableType`, `GenerationContext`, `GenerationResult`. |
+| `blueprint_loader.py` | Discovery and parsing. Resolves the blueprints directory (env override -> local checkout -> packaged), parses `blueprint.yaml`, validates against the model. |
+| `validators.py` | Variable validation: required fields, type coercion, choice membership. |
+| `variable_conditions.py` | Prunes variables whose `if` parent is falsy after collection. |
+| `planforge.py` | `scaffoldkit-input.json` schema (`PlanforgeExport`), variable mapping, inference rules, blueprint-candidate fallback. See [planforge-integration.md](planforge-integration.md). |
+| `scaffold_blueprint.py` | Backs `init-blueprint`: writes a starter `blueprint.yaml`, `templates/`, and `static/` skeleton. |
+
+## Generation pipeline
+
+A `scaffoldkit new` invocation runs the same pipeline whether the variables come from the TUI, `--var` flags, or a planforge export.
+
+1. **Resolve blueprints dir.** `SCAFFOLDKIT_BLUEPRINTS_DIR` env wins. Otherwise the loader walks up from `cwd` looking for a `pyproject.toml` plus `src/scaffoldkit/blueprints/` (so editing inside a checkout just works). Falls back to the packaged blueprints shipped with the wheel.
+2. **Load blueprint.** Parse `blueprint.yaml`, validate against the `Blueprint` model.
+3. **Collect variables.** Either via the TUI prompts or by merging `--var` flags with blueprint defaults under `--non-interactive`. Required variables without defaults still fail fast.
+4. **Validate.** `validators.py` checks required-ness, type coercion, choice membership.
+5. **Prune.** `variable_conditions.prune_inactive_variables` drops variables whose `if` parent is now falsy.
+6. **Build template context.** `generator.build_template_context` adds the variables, blueprint metadata (`blueprint_name`, `blueprint_display_name`, `blueprint_stack`), plus a fixed set of derived `is_*` flags so templates can branch on language, framework, package manager, config format, build tool, and stack without restating the same string compares.
+7. **Render templates.** Each `templates[]` entry is rendered through Jinja2; the optional `condition` field skips entries whose variable is falsy. Both the `source` and `target` paths are themselves Jinja-rendered, so templates can live in `{{ stack }}/...` style folders.
+8. **Copy static files.** Each `static_files[]` entry is copied verbatim from `static/` to its `target`.
+9. **Create directories.** Each `directories[]` entry is materialised under the target.
+10. **Post-generate hook.** If the generated tree has a `package.json` and `--no-install` was not passed, `cli.py` runs `npm install` in the target directory. Missing `npm` is a warning, not a failure.
+
+`--dry-run` short-circuits steps 7-10: paths are computed and printed but no bytes are written.
+
+## Watch and incremental?
+
+There isn't one. Generation is a one-shot operation. There is no daemon, no incremental rebuild, and no shared state between runs. Re-running into the same target directory requires `--overwrite`.
+
+## Design principles
+
+- **Declarative over hard-coded.** Blueprints are YAML, templates are Jinja2. Adding a stack is adding a folder, not editing the engine.
+- **Extensible over perfect.** The model is intentionally flat (no nested variables, no remote registry). New blueprints land as folders; new shipped blueprints are committed to `src/scaffoldkit/blueprints/`.
+- **Locally runnable.** No external services required. `from-planforge` reads a local file. Embeddings, networks, and daemons are out of scope.
+- **AI-friendly by design.** Every blueprint ships an `AI_CONTEXT.md`, an `architecture.md`, an ADR seed, and ways-of-working notes so a downstream Claude Code or Cursor session has real grounding from the first turn.
+
+## Technologies
+
+| Component | Technology |
+|-----------|-----------|
+| Language | Python 3.11+ |
+| CLI | [Typer](https://typer.tiangolo.com/) |
+| TUI Prompts | [questionary](https://github.com/tmbo/questionary) + [Rich](https://rich.readthedocs.io/) |
+| Templating | [Jinja2](https://jinja.palletsprojects.com/) |
+| YAML | [PyYAML](https://pyyaml.org/) |
+| Models | [Pydantic](https://docs.pydantic.dev/) v2 |
+| Packaging | [Hatch](https://hatch.pypa.io/) + [uv](https://docs.astral.sh/uv/) |
+| Container | Docker (optional) |
+
+## Repository layout
+
+```
+scaffoldkit/
+├── install.sh                # One-line installer (uv or Docker)
+├── Makefile                  # Build, test, install shortcuts
+├── Dockerfile                # Container build
+├── scaffoldkit-docker        # Docker wrapper script
+├── pyproject.toml
+├── src/
+│   └── scaffoldkit/
+│       ├── cli.py
+│       ├── tui.py
+│       ├── generator.py
+│       ├── blueprint_loader.py
+│       ├── renderer.py
+│       ├── filesystem.py
+│       ├── models.py
+│       ├── validators.py
+│       ├── variable_conditions.py
+│       ├── planforge.py
+│       ├── scaffold_blueprint.py
+│       └── blueprints/        # 13 shipped blueprints
+├── tests/                     # 78 tests: models, loader, validators, renderer, filesystem, generator, CLI, integration
+├── .github/workflows/ci.yml   # lint, mypy strict, pytest 3.11/3.12/3.13, build+install
+├── CONTRIBUTING.md
+├── CHANGELOG.md
+└── LICENSE
+```
+
+## Test suite
+
+78 tests cover:
+
+- **Models.** Data model construction and validation.
+- **Blueprint loading.** Discovery, parsing, error handling.
+- **Validators.** Required fields, type checks, choice validation.
+- **Renderer.** String rendering, template rendering, missing-variable errors.
+- **Filesystem.** Directory creation, file writing, copy, overwrite protection.
+- **Generator.** Full pipeline, dry-run, conditions, overwrite, static files.
+- **CLI.** Command help, blueprint listing, error paths.
+- **Integration.** End-to-end generation across stack/style/feature variations.
+
+CI runs ruff lint+format, mypy strict, pytest on Python 3.11, 3.12, 3.13, and a build+install verification on every push and PR to `main`.
+
+## Assumptions and limits
+
+- Python 3.11+ on the host (or via the `./install.sh` uv path, or via Docker).
+- Blueprints live alongside the source code. There is no remote registry yet.
+- Single-user local execution. No concurrency handling.
+- Blueprint variables are flat. Nested objects are not supported.

--- a/docs/blueprints.md
+++ b/docs/blueprints.md
@@ -1,0 +1,125 @@
+# Blueprints
+
+A blueprint is a self-contained folder that tells ScaffoldKit how to generate a project: what to ask the user, which files to render, which files to copy as-is, and which directories to create.
+
+## Folder layout
+
+```
+blueprints/<name>/
+├── blueprint.yaml    # Definition: metadata, variables, file mappings
+├── templates/        # Jinja2 templates (rendered with variables)
+└── static/           # Static files (copied as-is)
+```
+
+## `blueprint.yaml` structure
+
+```yaml
+name: my-blueprint
+display_name: "My Blueprint"
+description: "What this blueprint generates"
+version: "1.0.0"
+stack: "nextjs"
+
+variables:
+  - name: project_name
+    description: "Project slug"
+    type: string          # string | boolean | choice
+    default: "my-project"
+    required: true
+
+  - name: use_docker
+    type: boolean
+    default: true
+
+  - name: stack
+    type: choice
+    choices: ["nextjs", "remix", "astro"]
+    default: "nextjs"
+
+templates:
+  - source: README.md.j2        # Path inside templates/
+    target: README.md           # Path in generated project
+    condition: null             # Optional: variable that must be truthy
+
+static_files:
+  - source: .gitignore
+    target: .gitignore
+
+directories:
+  - src
+  - docs
+```
+
+### Variable types
+
+- `string`: free-form text, optional `default`.
+- `boolean`: `true`/`false`. Inputs like `yes`/`no`/`1`/`0` are normalised by the loader.
+- `choice`: must come with `choices: [...]`. The default (if absent or invalid) falls back to the first choice.
+
+Variables can be marked `required: true` (no default lookup, prompt or fail) or made conditional via the `if` field, in which case they are only collected when their parent flag is truthy. Inactive variables are pruned from the rendering context.
+
+### Template variables in Jinja
+
+All collected variables plus blueprint metadata are exposed to templates:
+
+```jinja
+# {{ display_name }}
+
+Stack: {{ stack }}
+{% if use_auth %}
+Authentication is enabled.
+{% endif %}
+```
+
+The generator also injects derived flags (`is_python`, `is_typescript`, `is_fastapi`, `is_nextjs_fullstack`, `is_uv`, `is_yaml_config`, etc.) so templates can branch on language/framework/package-manager without re-implementing string compares. See [architecture.md](architecture.md) for the full list.
+
+## Shipped blueprints
+
+ScaffoldKit ships 13 blueprints in `src/scaffoldkit/blueprints/`. `scaffoldkit list` always reflects the current set.
+
+| Name | Stack | Description |
+|------|-------|-------------|
+| `cli-tool` | cli | Command-line tool project skeleton with docs, tests, and AI context. |
+| `django-drf` | python-django | Production-ready Django REST Framework backend with project structure, API guidance, and AI context. |
+| `express-api` | express-api | TypeScript REST API with Express, Prisma, PostgreSQL, and AI agent context. |
+| `fastapi-backend` | python-fastapi | Production-ready FastAPI backend with layered application structure, API guidance, and AI context. |
+| `nextjs-frontend` | frontend | Production-ready Next.js frontend project skeleton with docs, conventions, and AI context. |
+| `nextjs-fullstack` | nextjs-fullstack | Full-stack Next.js application with Prisma, PostgreSQL, Tailwind CSS, and AI agent context. |
+| `reference-php-app` | php-symfony-reference | Reference Symfony/PHP repository scaffold with Docker, CI actions, security tooling, and a placeholder application mount. |
+| `rest-api` | backend | REST API project skeleton with layered architecture, docs, and AI context. |
+| `saas-dashboard` | fullstack | Full-stack SaaS dashboard with monorepo structure, docs, and AI context. |
+| `springboot-backend` | java-spring | Production-ready Spring Boot API backend with docs, architecture patterns, and AI context. |
+| `static-site` | static | Static website or documentation site with framework choice, styling, and deployment config. |
+| `symfony-backend` | php-symfony | Production-ready Symfony API backend with docs, architecture patterns, and AI context. |
+| `symfony-nextjs` | fullstack | Production-ready monorepo with Symfony API backend and Next.js frontend. |
+
+Every blueprint includes an `AI_CONTEXT.md`, an `architecture.md`, an ADR seed, and ways-of-working notes so a downstream Claude Code or Cursor session has real grounding from the first turn.
+
+## Adding a new blueprint
+
+The fastest path is `scaffoldkit init-blueprint`:
+
+```bash
+scaffoldkit init-blueprint my-new-blueprint
+```
+
+That creates `blueprints/my-new-blueprint/` with starter `blueprint.yaml`, `templates/`, and `static/` files. From there:
+
+1. Edit `blueprint.yaml` to declare metadata, variables, templates, static files, and directories.
+2. Add Jinja2 templates under `templates/`.
+3. Drop static files under `static/` (copied verbatim).
+4. `scaffoldkit list` to confirm discovery.
+5. `scaffoldkit new my-new-blueprint --dry-run --non-interactive --yes --var project_name=demo` to smoke-test.
+
+If you prefer to start from scratch, just create the folder by hand with the same three children. The blueprint loader picks up any folder under `blueprints/` that contains a valid `blueprint.yaml`.
+
+## Custom blueprint directories
+
+Point ScaffoldKit at a different directory either per-invocation:
+
+```bash
+scaffoldkit new --blueprints-dir ./my-blueprints my-custom
+scaffoldkit list -b ./my-blueprints
+```
+
+or globally via the `SCAFFOLDKIT_BLUEPRINTS_DIR` env var. When you are running from inside a scaffoldkit checkout the loader auto-detects `src/scaffoldkit/blueprints/` so local edits take effect immediately.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,209 @@
+# CLI reference
+
+ScaffoldKit ships a single `scaffoldkit` binary built on [Typer](https://typer.tiangolo.com/). Four subcommands: `new`, `from-planforge`, `init-blueprint`, `list`.
+
+## Installation
+
+No Python install required on your host. Pick the path that fits.
+
+### Option A: One-line installer (recommended)
+
+```bash
+git clone https://github.com/LanNguyenSi/scaffoldkit.git
+cd scaffoldkit
+./install.sh
+```
+
+Installs [uv](https://docs.astral.sh/uv/) (if missing), then uv handles Python and dependencies. The `scaffoldkit` command lands in `~/.local/bin`.
+
+### Option B: Docker (no Python on host)
+
+```bash
+git clone https://github.com/LanNguyenSi/scaffoldkit.git
+cd scaffoldkit
+./install.sh --docker
+```
+
+Builds the image and installs a thin wrapper. Only Docker and Bash required. You can also call the wrapper directly:
+
+```bash
+docker build -t scaffoldkit:latest .
+./scaffoldkit-docker --output ./my-projects -- new
+./scaffoldkit-docker -- list
+./scaffoldkit-docker --print -- new saas-dashboard      # show docker command, do not run
+./scaffoldkit-docker --build --output ./projects -- new # rebuild before running
+```
+
+### Option C: Makefile shortcuts
+
+```bash
+make install          # same as ./install.sh
+make install-docker   # same as ./install.sh --docker
+make dev              # create .venv with dev dependencies
+```
+
+### Option D: pipx (isolated installation)
+
+```bash
+python3 -m pip install --user pipx
+python3 -m pipx ensurepath
+
+git clone https://github.com/LanNguyenSi/scaffoldkit.git
+cd scaffoldkit
+pipx install .
+scaffoldkit --help
+```
+
+Isolated from system Python, no virtualenv activation, easy uninstall via `pipx uninstall scaffoldkit`.
+
+### Option E: venv (development setup)
+
+```bash
+git clone https://github.com/LanNguyenSi/scaffoldkit.git
+cd scaffoldkit
+python3 -m venv .venv
+source .venv/bin/activate          # Windows: .venv\Scripts\activate
+pip install -e ".[dev]"
+scaffoldkit --help
+```
+
+Use this when contributing, or when you need ruff/mypy/pytest installed.
+
+If you hit `externally-managed-environment` on Debian/Ubuntu, the venv path above is the fix.
+
+### Option F: Manual (Python 3.11+ already installed)
+
+```bash
+pip install .
+# or for development:
+uv venv .venv --python 3.12
+source .venv/bin/activate
+uv pip install -e ".[dev]"
+```
+
+## `scaffoldkit new`
+
+Generate a project from a blueprint.
+
+```bash
+scaffoldkit new [BLUEPRINT_NAME] [OPTIONS]
+```
+
+| Option | Description |
+|--------|-------------|
+| `BLUEPRINT_NAME` | Blueprint to use. Omit for the interactive picker. |
+| `-t, --target PATH` | Target directory for the generated project. |
+| `-n, --dry-run` | Preview without writing files. |
+| `--overwrite` | Overwrite existing files at the target. |
+| `--no-install` | Skip `npm install` after generation (Node blueprints only). |
+| `-b, --blueprints-dir PATH` | Use a custom blueprints directory. |
+| `--var KEY=VALUE` | Set a blueprint variable. Repeatable. |
+| `--non-interactive` | Use provided values plus blueprint defaults. Required vars without defaults still fail fast. |
+| `-y, --yes` | Skip the confirmation prompt. |
+
+`--var` accepts `true`/`false`, `yes`/`no`, `1`/`0` for booleans. Conditional variables are skipped automatically when their parent flag is disabled.
+
+### Interactive
+
+```bash
+scaffoldkit new
+```
+
+Launches the TUI: pick a blueprint, answer prompts for variables, choose a target directory, review, confirm. Generated files and directories are printed at the end.
+
+### Direct
+
+```bash
+scaffoldkit new saas-dashboard --target ./my-project
+```
+
+### Non-interactive
+
+```bash
+scaffoldkit new symfony-backend \
+  --target ./my-symfony-app \
+  --non-interactive --yes \
+  --var project_name=my-symfony-app \
+  --var display_name="My Symfony App" \
+  --var description="A Symfony-based API backend" \
+  --var php_version=8.3 \
+  --var symfony_version=7.2 \
+  --var api_style=api-platform \
+  --var database=postgresql \
+  --var use_ddd=true \
+  --var use_cqrs=true \
+  --var use_auth=false \
+  --var use_docker=true \
+  --var use_ci=true \
+  --var use_rabbitmq=false \
+  --var use_redis=false \
+  --var test_strategy=phpunit-only \
+  --var ai_context=true
+```
+
+### Post-generate npm install
+
+If the generated project contains a `package.json` and `--no-install` is not passed, `scaffoldkit new` runs `npm install` in the target directory after generation. Missing `npm` produces a warning, not a failure.
+
+## `scaffoldkit from-planforge`
+
+Generate from an `agent-planforge` export:
+
+```bash
+scaffoldkit from-planforge ./scaffoldkit-input.json --target ./my-project
+```
+
+Selects the recommended blueprint (with fallback resolution), maps planforge `suggestedVariables` onto the blueprint contract, and applies a small set of inference rules for things like `database`, `auth_strategy`, and `use_docker`. See [planforge-integration.md](planforge-integration.md) for the full schema and inference rules.
+
+Same `--target`, `--dry-run`, `--overwrite`, `--no-install`, `--blueprints-dir` flags as `new`.
+
+## `scaffoldkit init-blueprint`
+
+Scaffold a new blueprint folder under `blueprints/` with starter files.
+
+```bash
+scaffoldkit init-blueprint my-custom-stack
+```
+
+Creates `blueprints/my-custom-stack/` with `blueprint.yaml`, `templates/`, and `static/` skeletons. Edit, then `scaffoldkit list` to verify and `scaffoldkit new my-custom-stack` to test.
+
+## `scaffoldkit list`
+
+Print all available blueprints.
+
+```bash
+scaffoldkit list
+```
+
+Output:
+
+```
+Available blueprints:
+
+  cli-tool - CLI Tool
+    Command-line tool project skeleton with docs, tests, and AI context
+
+  fastapi-backend - FastAPI Backend
+    Production-ready FastAPI backend with layered application structure ...
+
+  ...
+```
+
+The blueprints directory is resolved in this order:
+
+1. `SCAFFOLDKIT_BLUEPRINTS_DIR` env var.
+2. A local checkout's `src/scaffoldkit/blueprints/` if you are running from inside a scaffoldkit clone.
+3. The packaged blueprints shipped with the installed wheel.
+
+`-b, --blueprints-dir PATH` overrides all of the above.
+
+## Docker wrapper
+
+```bash
+scaffoldkit-docker --output ./projects -- new                        # interactive
+scaffoldkit-docker -- list                                           # list blueprints
+scaffoldkit-docker --print -- new saas-dashboard                     # show docker command without running
+scaffoldkit-docker --build --output ./projects -- new                # rebuild image then run
+```
+
+Anything after `--` is passed straight to `scaffoldkit` inside the container. The `--output` host directory is mounted so generated projects land on your host filesystem.

--- a/docs/planforge-integration.md
+++ b/docs/planforge-integration.md
@@ -1,0 +1,111 @@
+# Planforge integration
+
+[agent-planforge](https://github.com/LanNguyenSi/agent-planforge) is a planning tool that turns a project brief into a `scaffoldkit-input.json` export. `scaffoldkit from-planforge` consumes that file and generates a project without re-prompting for variables planforge already decided.
+
+## Usage
+
+```bash
+scaffoldkit from-planforge ./scaffoldkit-input.json --target ./my-project
+```
+
+Same flags as `scaffoldkit new` except for `--var` / `--non-interactive` / `--yes`: planforge supplies those values. The supported flags are `--target`, `--dry-run`, `--overwrite`, `--no-install`, `--blueprints-dir`.
+
+If the planforge-recommended blueprint isn't installed locally, the resolver walks `blueprintCandidates` in order and falls back to the first match, printing which fallback it picked. If none match, you get the candidate list plus the locally available blueprints in the error output.
+
+## `scaffoldkit-input.json` schema
+
+The export is validated against `PlanforgeExport` (see `src/scaffoldkit/planforge.py`):
+
+```json
+{
+  "version": "1.0",
+  "exportedBy": "agent-planforge",
+  "projectName": "Acme Billing API",
+  "summary": "Internal billing service for invoices and subscriptions.",
+  "blueprint": "fastapi-backend",
+  "blueprintCandidates": ["rest-api"],
+  "blueprintReason": "Python ecosystem, OpenAPI required.",
+  "plannerProfile": "backend-service",
+  "architecture": {
+    "shape": "layered service with workers",
+    "optionId": "layered-v1",
+    "phase": "mvp",
+    "path": "monolith"
+  },
+  "stack": {
+    "hint": "FastAPI + Postgres + Redis",
+    "dataStore": "postgresql",
+    "integrations": ["stripe", "sendgrid"]
+  },
+  "features": ["billing", "invoices", "background jobs"],
+  "constraints": ["docker", "openapi"],
+  "suggestedVariables": {
+    "use_docker": true,
+    "use_redis": true,
+    "auth_strategy": "jwt"
+  }
+}
+```
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `projectName` | yes | Source for `project_name` (slugified) and `display_name`. |
+| `blueprint` | yes | Primary blueprint candidate. |
+| `version` | no | Free-form. Currently unused. |
+| `exportedBy` | no | Free-form. |
+| `summary` | no | Drives the inferred `description` and several signal regexes. |
+| `blueprintCandidates` | no | Ordered fallbacks if `blueprint` is not installed. |
+| `blueprintReason` | no | Surfaced in the error output if no candidate resolves. |
+| `plannerProfile` | no | Free-form planner identifier. |
+| `architecture.shape` | no | Free-form architecture description, mined for signals. |
+| `architecture.optionId` / `phase` / `path` | no | Free-form passthroughs. |
+| `stack.hint` | no | Free-form stack description, mined for `language` / `framework` signals. |
+| `stack.dataStore` | no | Used for database inference, defaults to `relational`. |
+| `stack.integrations` | no | Free-form list of integration tags. |
+| `features` | no | Free-form list, mined for queue/notification/realtime signals. |
+| `constraints` | no | Free-form list, mined for docker/api-key signals. |
+| `suggestedVariables` | no | Direct map onto blueprint variables. Unsupported keys are ignored with a warning. |
+
+Empty `summary`, `features`, `constraints`, or `architecture.shape` print a warning explaining which inference paths fall back to blueprint defaults.
+
+## Variable mapping
+
+`from-planforge` populates blueprint variables in this order:
+
+1. Start with the blueprint's declared defaults.
+2. Set `project_name` to a slug of `projectName`. Set `display_name` to `projectName`. Set `description` to `summary` (or `projectName` if blank).
+3. Set `ai_context = true` if the blueprint has that variable.
+4. Apply every key in `suggestedVariables` that maps to a real blueprint variable. Unsupported keys are listed in a warning.
+5. For variables planforge did not set (and the blueprint default is unchanged), apply the inference rules below.
+6. Normalise everything through the blueprint's type contract: booleans accept `true`/`yes`/`1`, choices clamp to declared options or fall back to the default.
+7. Prune variables whose `if` parent is now falsy.
+
+### Inference rules
+
+The combined text of `projectName`, `summary`, `features`, `constraints`, `architecture.shape`, and `stack.hint` is searched for keywords:
+
+| Variable | Trigger |
+|----------|---------|
+| `use_docker` | `docker`, `container`, `kubernetes`, `compose`. |
+| `language` | `typescript` -> `typescript`, `\bgo\b` -> `go`, `rust` -> `rust`, otherwise `python`. |
+| `cli_framework` | Derived from `language`: python -> `typer`, go -> `cobra`, rust -> `clap`, typescript -> `commander`. |
+| `distribution` | Compiled languages get `binary`, otherwise `pip-package`. |
+| `test_strategy` | `git`/`sync`/`filesystem`/`queue`/`workflow`/`remote` -> `integration-tests`, otherwise `unit-tests`. Blueprint-specific overrides for `fastapi-backend` and `django-drf`. |
+| `use_analytics` | `analytics`/`dashboard`/`report`. |
+| `use_email` | `email`/`notification`/`invite`. |
+| `use_queue` | `background jobs`/`queue`/`workflow`/`notification`. |
+| `use_auth` | Forced `false` when `public-only`/`anonymous`/`no auth` appears. |
+| `use_openapi` | Default `true`. |
+| `db_provider` / `database` | `sqlite`/`mysql`/`mongo` keywords map to the matching choice, default `postgresql`. |
+| `framework` | TypeScript hint -> `express`, otherwise `fastapi`. |
+| `auth_strategy` | `public-only`/`anonymous` -> `none`, `api key` -> `api-key` (`token` for django-drf), `oauth2` -> `oauth2`, `sso`/`next-auth` (nextjs-fullstack only) -> `next-auth`, otherwise `jwt`. |
+
+Blueprint-specific extras live alongside these rules. See `src/scaffoldkit/planforge.py` for the canonical implementation.
+
+### Generic API fallback
+
+If planforge picks `rest-api` but the brief mentions Django/DRF/serializers, the resolver inserts `django-drf` ahead of `rest-api`. If it mentions FastAPI/Pydantic/uvicorn/Python, it inserts `fastapi-backend`. This keeps planforge from having to know every Python web framework upfront.
+
+## Producing a `scaffoldkit-input.json`
+
+Planforge owns the export contract. From the planforge UI, the "Generate scaffold input" action writes the JSON to your chosen path; from the planforge CLI it lands next to your plan. Once you have the file, point `scaffoldkit from-planforge` at it.


### PR DESCRIPTION
## Summary

Cuts the ScaffoldKit README from 473 to 92 lines and moves deep content into `docs/`. A first-time visitor now gets a tagline, a one-paragraph explainer, a runnable 60-second `scaffoldkit new cli-tool` block, the actual generator output, and a four-row "next steps" table linking to the new docs.

- New `docs/blueprints.md`: declarative blueprint format, variable types, every shipped blueprint listed in a table, how to add a blueprint via `scaffoldkit init-blueprint`.
- New `docs/planforge-integration.md`: full `scaffoldkit-input.json` schema, variable-mapping pipeline, inference rules from `planforge.py`.
- New `docs/architecture.md`: layer diagram, module-by-module map, 10-step generation pipeline, design principles, repo layout, test suite.
- New `docs/cli.md`: every install path (uv, Docker, Makefile, pipx, venv, manual) plus full reference for `new`, `from-planforge`, `init-blueprint`, `list`, and the docker wrapper.

## Acceptance

- README is 92 lines (target under 200, was 473).
- 60-second block uses the real `scaffoldkit new cli-tool` invocation; output captured locally from running the binary.
- All 13 shipped blueprints listed in `docs/blueprints.md`.
- Every subcommand from old README still discoverable in docs/.
- No em dashes.
- All internal links resolve.

Mirrors the README hook pattern from codebase-oracle PR #21, depsight PR #44, agent-relay PR #33, agent-tasks PR #199.

Closes task `6028a562-89c2-4607-8b78-e7584592ec93`.