### PR TITLE
docs: complete open source surface (LICENSE holder, CoC, security, templates)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,47 @@
+name: Bug report
+description: Report a defect in scaffoldkit
+labels: ["bug"]
+body:
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Surface
+      options:
+        - blueprint engine
+        - template rendering
+        - CLI
+        - Docker image
+        - install.sh
+        - other / unsure
+    validations:
+      required: true
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened?
+      description: Expected vs. actual behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction steps
+      description: Minimal blueprint or commands that trigger the bug.
+      render: bash
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: scaffoldkit version
+      placeholder: "0.x.y"
+  - type: input
+    id: python
+    attributes:
+      label: Python version
+      placeholder: "3.12"
+  - type: input
+    id: os
+    attributes:
+      label: OS
+      placeholder: "macOS 14 / Ubuntu 22.04 / Windows 11"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security report
+    url: https://github.com/LanNguyenSi/scaffoldkit/blob/master/SECURITY.md
+    about: Please report vulnerabilities privately, not via public issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,20 @@
+name: Feature request
+description: Propose a new blueprint feature, hook, or capability
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: usecase
+    attributes:
+      label: Use case
+      description: What problem does this solve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Sketch the blueprint extension, hook, or workflow change.
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,7 @@
 
 - [ ] `pytest tests/`
 - [ ] `ruff check src/ tests/`
+- [ ] `ruff format --check src/ tests/` (CI also enforces this)
 - [ ] For blueprint changes: generated a sample project and verified output
 - [ ] Manual smoke check: <!-- command or scenario -->
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Summary
+
+<!-- One or two sentences. What changed? -->
+
+## Motivation
+
+<!-- Why this change? Link the issue if applicable. -->
+
+## Test plan
+
+- [ ] `pytest tests/`
+- [ ] `ruff check src/ tests/`
+- [ ] For blueprint changes: generated a sample project and verified output
+- [ ] Manual smoke check: <!-- command or scenario -->
+
+## Notes for reviewer
+
+<!-- Anything non-obvious. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,9 @@
+# Code of Conduct
+
+This project adopts the [Contributor Covenant 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+
+By participating, you agree to uphold its standards.
+
+## Reporting
+
+Report incidents to **contact@lan-nguyen-si.de**. Reports are kept confidential.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 ScaffoldKit Contributors
+Copyright (c) 2026 Lan Nguyen Si
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-Active development is on `master`. Only the latest published release on PyPI is supported.
+Active development is on `master`. Once published to PyPI, only the latest release will be supported; until then, `master` is the supported state.
 
 scaffoldkit generates project skeletons from declarative blueprints; vulnerabilities (path traversal in templates, code injection via blueprint content, supply-chain risk in generated dependencies) are treated as serious.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Supported Versions
+
+Active development is on `master`. Only the latest published release on PyPI is supported.
+
+scaffoldkit generates project skeletons from declarative blueprints; vulnerabilities (path traversal in templates, code injection via blueprint content, supply-chain risk in generated dependencies) are treated as serious.
+
+## Reporting a Vulnerability
+
+Please **do not** open a public GitHub issue for security reports.
+
+Email **contact@lan-nguyen-si.de** with:
+
+- Affected version
+- Reproduction steps or proof-of-concept
+- Impact assessment
+
+You will get an acknowledgement within 72 hours and an initial assessment within 7 days. A fix timeline depends on severity and complexity, communicated in the assessment.


### PR DESCRIPTION
## Summary

LICENSE and CONTRIBUTING already shipped. This PR completes the OSS surface:

- `LICENSE`: copyright holder `ScaffoldKit Contributors` → `Lan Nguyen Si` (matches org default)
- `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1, by reference)
- `SECURITY.md` (template-injection / supply-chain framing; contact@lan-nguyen-si.de)
- `.github/ISSUE_TEMPLATE/bug_report.yml`, `feature_request.yml`, `config.yml`
- `.github/pull_request_template.md`

CONTRIBUTING preserved unchanged (already extensive Python / uv / pytest setup).

## Motivation

Closes the open-source-checklist task for scaffoldkit.

## Test plan

- [x] All 7 changed/new files render in GitHub preview
- [x] All 3 issue YAMLs parse via `yaml.safe_load`
- [x] slop-detector clean
- [x] No em-dashes
- [x] No source code touched