### PR TITLE
chore: set pyproject authors to Lan Nguyen Si

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "AI-aided project scaffolding tool with declarative blueprints"
 readme = "README.md"
 requires-python = ">=3.11"
 license = "MIT"
-authors = [{ name = "ScaffoldKit Contributors" }]
+authors = [{ name = "Lan Nguyen Si", email = "contact@lan-nguyen-si.de" }]
 keywords = ["scaffolding", "project-generator", "blueprints", "templates", "cli"]
 classifiers = [
     "Development Status :: 3 - Alpha",


### PR DESCRIPTION
Aligns `pyproject.toml#authors` with the LICENSE copyright holder.

Follow-up from PR #42 review: LICENSE was updated to `Copyright (c) 2026 Lan Nguyen Si` but the authors field in `pyproject.toml` still said `ScaffoldKit Contributors`.

## Changes
- `pyproject.toml`: `authors = [{ name = "Lan Nguyen Si", email = "contact@lan-nguyen-si.de" }]`

Closes task `831eb5e3`.