### PR TITLE
fix(security): contain generated paths under target_dir (HIGH audit)

### DIFF
--- a/src/scaffoldkit/generator.py
+++ b/src/scaffoldkit/generator.py
@@ -2,13 +2,31 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from scaffoldkit.filesystem import copy_file, ensure_directory, write_file
 from scaffoldkit.models import Blueprint, GenerationContext, GenerationResult
 from scaffoldkit.renderer import create_jinja_env, render_string, render_template
 from scaffoldkit.validators import validate_variables
 from scaffoldkit.variable_conditions import prune_inactive_variables
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _safe_join(base: Path, rel: str) -> Path:
+    """Join a rendered relative path onto base, refusing anything that escapes base.
+
+    Rendered values come from untrusted sources (user --var input and third-party
+    blueprints), so an absolute value or one containing '..' must not be allowed to
+    write outside the target directory. Raises ValueError when the resolved path is
+    not contained within base.
+    """
+    base_resolved = base.resolve()
+    candidate = (base_resolved / rel).resolve()
+    if not candidate.is_relative_to(base_resolved):
+        raise ValueError(f"path '{rel}' escapes the target directory")
+    return candidate
 
 
 def build_template_context(blueprint: Blueprint, variables: dict[str, Any]) -> dict[str, Any]:
@@ -89,10 +107,17 @@ def generate(context: GenerationContext) -> GenerationResult:
 
     # 4. Create explicit directories
     for dir_pattern in blueprint.directories:
-        dir_path = context.target_dir / render_string(dir_pattern, tpl_context)
+        dir_rel = render_string(dir_pattern, tpl_context)
+        try:
+            dir_path = _safe_join(context.target_dir, dir_rel)
+        except ValueError as e:
+            result.errors.append(f"Unsafe directory '{dir_rel}': {e}")
+            continue
         created = ensure_directory(dir_path) if not context.dry_run else True
         if created:
-            result.directories_created.append(str(dir_path.relative_to(context.target_dir)))
+            result.directories_created.append(
+                str(dir_path.relative_to(context.target_dir.resolve()))
+            )
 
     # 5. Render templates
     template_dir = bp_path / "templates"
@@ -103,7 +128,11 @@ def generate(context: GenerationContext) -> GenerationResult:
                 continue
 
             target_rel = render_string(entry.target, tpl_context)
-            target_path = context.target_dir / target_rel
+            try:
+                target_path = _safe_join(context.target_dir, target_rel)
+            except ValueError as e:
+                result.errors.append(f"Unsafe template target '{target_rel}': {e}")
+                continue
 
             try:
                 content = render_template(env, entry.source, tpl_context)
@@ -129,7 +158,11 @@ def generate(context: GenerationContext) -> GenerationResult:
 
             target_rel = render_string(entry.target, tpl_context)
             source_path = static_dir / entry.source
-            target_path = context.target_dir / target_rel
+            try:
+                target_path = _safe_join(context.target_dir, target_rel)
+            except ValueError as e:
+                result.errors.append(f"Unsafe static target '{target_rel}': {e}")
+                continue
 
             if not source_path.exists():
                 result.errors.append(f"Static file not found: {entry.source}")

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from scaffoldkit.blueprint_loader import load_blueprint
 from scaffoldkit.generator import build_template_context, generate
-from scaffoldkit.models import GenerationContext
+from scaffoldkit.models import Blueprint, GenerationContext
 
 BLUEPRINTS_DIR = Path(__file__).resolve().parent.parent / "src" / "scaffoldkit" / "blueprints"
 
@@ -132,3 +132,66 @@ class TestGenerate:
         readme = (tmp_path / "output" / "README.md").read_text()
         assert "# Test Project" in readme
         assert "nextjs-fullstack" in readme
+
+
+class TestPathTraversal:
+    """A rendered target (from --var input or a third-party blueprint) must never
+    escape the target directory."""
+
+    def _bp(self, **fields) -> Blueprint:
+        base = dict(name="evil", display_name="Evil")
+        base.update(fields)
+        return Blueprint(**base)
+
+    def test_absolute_directory_rejected(self, tmp_path):
+        outside = tmp_path / "outside"
+        bp = self._bp(directories=[str(outside / "pwned")])
+        ctx = GenerationContext(
+            blueprint=bp,
+            blueprint_path=tmp_path / "bp",
+            variables={},
+            target_dir=tmp_path / "output",
+        )
+        result = generate(ctx)
+        assert not result.success
+        assert any("Unsafe directory" in e for e in result.errors)
+        assert not (outside / "pwned").exists()
+
+    def test_dotdot_directory_rejected(self, tmp_path):
+        bp = self._bp(directories=["../../escaped"])
+        ctx = GenerationContext(
+            blueprint=bp,
+            blueprint_path=tmp_path / "bp",
+            variables={},
+            target_dir=tmp_path / "output",
+        )
+        result = generate(ctx)
+        assert not result.success
+        assert any("Unsafe directory" in e for e in result.errors)
+        assert not (tmp_path / "escaped").exists()
+
+    def test_var_driven_traversal_rejected(self, tmp_path):
+        # Untrusted --var value rendered into a directory pattern.
+        bp = self._bp(directories=["{{ base_package }}/pkg"])
+        ctx = GenerationContext(
+            blueprint=bp,
+            blueprint_path=tmp_path / "bp",
+            variables={"base_package": "../../../../tmp/sk_escape"},
+            target_dir=tmp_path / "output",
+        )
+        result = generate(ctx)
+        assert not result.success
+        assert any("Unsafe directory" in e for e in result.errors)
+
+    def test_safe_nested_directory_allowed(self, tmp_path):
+        # Negative control: a legitimate nested path still works.
+        bp = self._bp(directories=["src/main/java/com/acme"])
+        ctx = GenerationContext(
+            blueprint=bp,
+            blueprint_path=tmp_path / "bp",
+            variables={},
+            target_dir=tmp_path / "output",
+        )
+        result = generate(ctx)
+        assert result.success
+        assert (tmp_path / "output" / "src" / "main" / "java" / "com" / "acme").is_dir()


### PR DESCRIPTION
Fixes the confirmed HIGH-severity path-traversal finding in the scaffold generator. Rendered directory and file targets are derived from untrusted sources (user `--var` input and third-party blueprints) and were joined onto `target_dir` with no boundary check. Because pathlib `/` discards the left side when the right side is absolute and follows `..` upward, a rendered value like `/etc/cron.d/x` or `../../../tmp/x` escaped the target directory, enabling arbitrary file writes.

## Findings fixed

- Path traversal in the generation engine (`src/scaffoldkit/generator.py`): added a `_safe_join(base, rel)` helper (generator.py:14) that resolves `(base / rel).resolve()` and raises `ValueError` unless the result `is_relative_to(base.resolve())`, rejecting absolute and `..`-containing rendered values. Routed all three write sinks through it, failing closed by collecting the rejection in `result.errors` and skipping the entry (matching the existing error-collection idiom in `generate()`):
  - directories loop, generator.py:106-116 (guards the sink at former line 92)
  - template targets, generator.py:126-131 (guards the sink at former line 106)
  - static-file targets, generator.py:155-161 (guards the sink at former line 132)
  - the `relative_to` display call in the directories loop was updated to use the resolved base so it stays consistent with the now-resolved `dir_path`.

Added regression tests in `tests/test_generator.py` (TestPathTraversal): absolute-directory reject, `..` reject, `--var`-driven traversal reject, plus a negative control asserting a legitimate nested path (`src/main/java/com/acme`) still generates.

## Verification

- `.venv/bin/python -m mypy src/scaffoldkit/generator.py`: Success, no issues found.
- `.venv/bin/python -m pytest -q`: 267 passed (263 prior + 4 new traversal tests).
- `.venv/bin/python -m py_compile src/scaffoldkit/generator.py`: clean.

Refs: 2026-05-30 security audit (HIGH)