### PR TITLE
feat(from-planforge): add --no-ai-context to suppress blueprint AI-context emission

### DIFF
--- a/src/scaffoldkit/cli.py
+++ b/src/scaffoldkit/cli.py
@@ -201,6 +201,18 @@ def from_planforge(
     no_install: Annotated[
         bool, typer.Option("--no-install", help="Skip npm install after generation")
     ] = False,
+    no_ai_context: Annotated[
+        bool,
+        typer.Option(
+            "--no-ai-context",
+            help=(
+                "Do not emit the blueprint's AI-context files (the .ai/ tree and "
+                "AI_CONTEXT.md). Use when the caller already provides its own agent "
+                "context, e.g. the agent-planforge container, whose .ai/ would "
+                "otherwise be clobbered by --overwrite."
+            ),
+        ),
+    ] = False,
     blueprints_dir: Annotated[
         Path | None, typer.Option("--blueprints-dir", "-b", help="Custom blueprints dir")
     ] = None,
@@ -246,6 +258,13 @@ def from_planforge(
         console.print(f"[yellow]Planforge input warning: {warning}[/yellow]")
 
     variables = build_variables_from_planforge(export_data, blueprint)
+
+    # The planforge container writes its own canonical root .ai/ tree before invoking
+    # from-planforge, so it owns the AI context. --no-ai-context lets such a caller
+    # suppress scaffoldkit's ai_context-gated files (the .ai/ tree and AI_CONTEXT.md)
+    # instead of having --overwrite silently clobber the caller's .ai/.
+    if no_ai_context and "ai_context" in variables:
+        variables["ai_context"] = False
 
     resolved_target = (
         target.resolve() if target else (Path.cwd() / default_target_name(export_data)).resolve()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -135,6 +135,97 @@ class TestFromPlanforgeCommand:
         assert (target / "package.json").exists()
         assert (target / ".ai" / "AGENTS.md").exists()
 
+    def test_no_ai_context_suppresses_ai_files_but_keeps_scaffold(self, tmp_path):
+        export_path = tmp_path / "scaffoldkit-input.json"
+        target = tmp_path / "generated-app"
+        export_path.write_text(
+            json.dumps(
+                {
+                    "version": "1.1",
+                    "exportedBy": "agent-planforge",
+                    "projectName": "Ops Console",
+                    "summary": "Internal operations dashboard with audit-aware workflows.",
+                    "blueprint": "nextjs-fullstack",
+                    "blueprintCandidates": ["nextjs-fullstack", "saas-dashboard"],
+                    "features": ["analytics dashboard", "user authentication"],
+                    "constraints": ["must be dockerized", "prefer TypeScript"],
+                    "architecture": {"shape": "modular monolith"},
+                    "stack": {"hint": "TypeScript web application", "dataStore": "relational"},
+                    "suggestedVariables": {
+                        "db_provider": "sqlite",
+                        "use_docker": True,
+                        "use_analytics": True,
+                        "auth_strategy": "jwt",
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = runner.invoke(
+            app,
+            [
+                "from-planforge",
+                str(export_path),
+                "--target",
+                str(target),
+                "--no-install",
+                "--no-ai-context",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        # AI-context files are suppressed: the caller (e.g. planforge) owns .ai/.
+        # (test_generates_project_from_planforge_export is the negative control:
+        # the same export WITHOUT the flag emits .ai/AGENTS.md.)
+        assert not (target / ".ai" / "AGENTS.md").exists()
+        assert not (target / ".ai" / "ARCHITECTURE.md").exists()
+        assert not (target / "AI_CONTEXT.md").exists()
+        # The rest of the scaffold is unaffected by the flag.
+        assert (target / "README.md").exists()
+        assert (target / "package.json").exists()
+
+    def test_no_ai_context_preserves_caller_ai_files_under_overwrite(self, tmp_path):
+        # Regression for the agent-planforge contract: planforge writes its own
+        # .ai/ into the target first, then invokes from-planforge --overwrite. With
+        # --no-ai-context, scaffoldkit must NOT clobber the caller's .ai/ files.
+        export_path = tmp_path / "scaffoldkit-input.json"
+        target = tmp_path / "generated-app"
+        (target / ".ai").mkdir(parents=True)
+        sentinel = target / ".ai" / "AGENTS.md"
+        sentinel.write_text("PLANFORGE-ORIGINAL", encoding="utf-8")
+        export_path.write_text(
+            json.dumps(
+                {
+                    "version": "1.1",
+                    "exportedBy": "agent-planforge",
+                    "projectName": "Ops Console",
+                    "summary": "Internal operations dashboard.",
+                    "blueprint": "nextjs-fullstack",
+                    "stack": {"hint": "TypeScript web application", "dataStore": "relational"},
+                    "suggestedVariables": {"db_provider": "sqlite"},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = runner.invoke(
+            app,
+            [
+                "from-planforge",
+                str(export_path),
+                "--target",
+                str(target),
+                "--no-install",
+                "--overwrite",
+                "--no-ai-context",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        # The caller's pre-existing .ai/ file survives despite --overwrite.
+        assert sentinel.read_text(encoding="utf-8") == "PLANFORGE-ORIGINAL"
+
     def test_falls_back_to_candidate_blueprint_when_primary_is_missing(self, tmp_path):
         export_path = tmp_path / "scaffoldkit-input.json"
         target = tmp_path / "generated-app"


### PR DESCRIPTION
## What
Add a `--no-ai-context` flag to `from-planforge` that suppresses scaffoldkit's AI-context emission (the `.ai/` tree and `AI_CONTEXT.md`).

## Why
In the agent-planforge HTTP container, `generate.ts` runs the planforge CLI (which writes a rich, plan-derived root `.ai/{AGENTS,ARCHITECTURE,TASKS,DECISIONS}.md`) and then `scaffoldkit.cli from-planforge <input> --target <same outdir> --overwrite`. `from_planforge` force-sets `ai_context=True` and `--overwrite` is a global force-all, so for the two blueprints that ship a root `.ai/` tree (express-api, nextjs-fullstack) scaffoldkit's static placeholders silently clobber planforge's files. Verified 2 of 13 blueprints emit `.ai/`.

## Change
`--no-ai-context` overrides `ai_context=False` after `build_variables_from_planforge`, so no ai_context-gated file is emitted on this path. Rationale: planforge writes its own canonical `.ai/` unconditionally, so it owns the AI context; scaffoldkit's emission is redundant when the caller opts in. The interactive `new` path is untouched (default false).

## Verification
- New test asserts `--no-ai-context` suppresses `.ai/*.md` + `AI_CONTEXT.md` while keeping the rest of the scaffold; the existing nextjs-fullstack test is the negative control.
- Regression test: a pre-existing `.ai/AGENTS.md` survives `--overwrite --no-ai-context` (the planforge contract).
- ruff check + ruff format + mypy + full pytest (now 270) green. Reviewed by subagent: APPROVE.

## Rollout
Consumer-first: this ships, then agent-planforge bumps `SCAFFOLDKIT_REF` to this commit and passes `--no-ai-context` from `generate.ts` in one PR (the container pin guarantees no version skew). Pairs with agent-planforge bug task 8e10ec47.

Refs: task 9c54038e