### PR TITLE
chore(release): v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-06-01
+
+### Added
+
+- `scaffoldkit from-planforge --no-ai-context` to suppress blueprint AI-context file emission ([#45](https://github.com/LanNguyenSi/scaffoldkit/pull/45))
+
+### Security
+
+- Contain all generated paths under the target directory, blocking path traversal and absolute-path escapes during generation ([#44](https://github.com/LanNguyenSi/scaffoldkit/pull/44))
+
+### Changed
+
+- Documentation and packaging: README 60s hook restructured into `docs/`, completed open source surface (LICENSE holder, Code of Conduct, security policy, issue templates), and `pyproject.toml` authors set to Lan Nguyen Si ([#41](https://github.com/LanNguyenSi/scaffoldkit/pull/41), [#42](https://github.com/LanNguyenSi/scaffoldkit/pull/42), [#43](https://github.com/LanNguyenSi/scaffoldkit/pull/43))
+
 ## [0.1.0] - 2026-04-27
 
 First public release.
@@ -76,5 +90,6 @@ A `Dockerfile` and `docker-compose.yml` are shipped for the Docker path.
 - Single-user local execution; no concurrency guards.
 - Blueprint variables are flat (no nested objects).
 
-[Unreleased]: https://github.com/LanNguyenSi/scaffoldkit/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/LanNguyenSi/scaffoldkit/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/LanNguyenSi/scaffoldkit/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/LanNguyenSi/scaffoldkit/releases/tag/v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scaffoldkit"
-version = "0.1.0"
+version = "0.2.0"
 description = "AI-aided project scaffolding tool with declarative blueprints"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Release v0.2.0

First release since v0.1.0. No source changes in this PR: it fills the `[Unreleased]` changelog into `[0.2.0]` and bumps the version.

### Highlights

- **Added:** `scaffoldkit from-planforge --no-ai-context` to suppress blueprint AI-context file emission (#45).
- **Security:** generated paths are now contained under the target directory, blocking path-traversal and absolute-path escapes during generation (HIGH audit, #44).
- **Changed:** documentation and packaging, the README 60s hook moved into `docs/`, a completed open-source surface, and pyproject authors set to Lan Nguyen Si (#41, #42, #43).

Version bumped to 0.2.0 in `pyproject.toml`. Merging this and pushing tag `v0.2.0` triggers the tag-driven release workflow, which verifies the pyproject version matches the tag and builds the wheel and sdist.

Refs: agent-tasks 04e28de1