### PR TITLE
chore: gitignore uv.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ build/
 venv/
 env/
 
+# uv: lockfile is intentionally not tracked (CI resolves fresh via `uv sync`, no --frozen)
+uv.lock
+
 # Testing
 .pytest_cache/
 .coverage


### PR DESCRIPTION
## What

Adds `uv.lock` to `.gitignore`. uv writes `uv.lock` on every `uv run` / `uv sync`, but scaffoldkit never tracked it, so the generated lock sat untracked and dirtied the worktree, tripping the repo-cleanliness hook (`scaffoldkit: outcome=skipped_dirty reason=worktree_dirty untracked=1`) on every check.

## Why this is safe

CI resolves dependencies fresh: `ci.yml` uses `uv sync --extra dev` (no `--frozen`), and both `ci.yml` and `release.yml` use `uv build` / `uv run`. None require a committed lock, and the published wheel/sdist does not ship it. `uv.lock` was never tracked, so nothing leaves version control. Reviewed read-only, verdict pass.

Refs: agent-tasks 9edfc261