### PR TITLE
fix(blueprints): emit real runnable starter source for rest-api and cli-tool

### DIFF
--- a/src/scaffoldkit/blueprints/cli-tool/blueprint.yaml
+++ b/src/scaffoldkit/blueprints/cli-tool/blueprint.yaml
@@ -132,6 +132,32 @@ templates:
     target: AI_CONTEXT.md
     condition: ai_context
 
+  # Minimal runnable Python starter (entry module, one command, smoke test) so a
+  # python cli-tool scaffold ships real source instead of only a pyproject.toml.
+  - source: src/__init__.py.j2
+    target: src/__init__.py
+    condition: is_python
+
+  - source: src/main.py.j2
+    target: src/main.py
+    condition: is_python
+
+  - source: src/commands/__init__.py.j2
+    target: src/commands/__init__.py
+    condition: is_python
+
+  - source: src/commands/run.py.j2
+    target: src/commands/run.py
+    condition: is_python
+
+  - source: tests/__init__.py.j2
+    target: tests/__init__.py
+    condition: is_python
+
+  - source: tests/test_run.py.j2
+    target: tests/test_run.py
+    condition: is_python
+
   - source: package.json.j2
     target: package.json
     condition: is_typescript

--- a/src/scaffoldkit/blueprints/cli-tool/templates/pyproject.toml.j2
+++ b/src/scaffoldkit/blueprints/cli-tool/templates/pyproject.toml.j2
@@ -27,4 +27,7 @@ dev = [
 ]
 
 [project.scripts]
-{{ project_name | replace('-', '_') }} = "src.main:app"
+{{ project_name }} = "src.main:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src"]

--- a/src/scaffoldkit/blueprints/cli-tool/templates/src/__init__.py.j2
+++ b/src/scaffoldkit/blueprints/cli-tool/templates/src/__init__.py.j2
@@ -1,0 +1,1 @@
+"""{{ display_name }} command-line application package."""

--- a/src/scaffoldkit/blueprints/cli-tool/templates/src/commands/__init__.py.j2
+++ b/src/scaffoldkit/blueprints/cli-tool/templates/src/commands/__init__.py.j2
@@ -1,0 +1,1 @@
+"""Command implementations for {{ project_name }}."""

--- a/src/scaffoldkit/blueprints/cli-tool/templates/src/commands/run.py.j2
+++ b/src/scaffoldkit/blueprints/cli-tool/templates/src/commands/run.py.j2
@@ -1,0 +1,19 @@
+{% if cli_framework == "click" -%}
+"""The `run` command."""
+import click
+
+
+@click.command(help="Run the primary {{ project_name }} workflow.")
+@click.option("--name", default="world", help="Who to greet.")
+def run(name: str) -> None:
+    """Execute the main task."""
+    click.echo(f"Hello, {name}!")
+{% else -%}
+"""The `run` command."""
+import typer
+
+
+def run(name: str = typer.Option("world", help="Who to greet.")) -> None:
+    """Run the primary {{ project_name }} workflow."""
+    typer.echo(f"Hello, {name}!")
+{% endif -%}

--- a/src/scaffoldkit/blueprints/cli-tool/templates/src/main.py.j2
+++ b/src/scaffoldkit/blueprints/cli-tool/templates/src/main.py.j2
@@ -1,0 +1,40 @@
+{% if cli_framework == "click" -%}
+"""{{ display_name }} - command-line entry point."""
+import click
+
+from src.commands.run import run
+
+
+@click.group(help="{{ description }}")
+@click.version_option("0.1.0")
+def app() -> None:
+    """{{ display_name }} command-line interface."""
+
+
+app.add_command(run)
+
+
+if __name__ == "__main__":
+    app()
+{% else -%}
+"""{{ display_name }} - command-line entry point."""
+import typer
+
+from src.commands import run as run_command
+
+app = typer.Typer(help="{{ description }}", no_args_is_help=True)
+
+
+@app.callback()
+def main() -> None:
+    """{{ display_name }} command-line interface."""
+
+
+# The callback above keeps `run` a named subcommand instead of Typer collapsing
+# a single-command app into the root invocation.
+app.command(name="run")(run_command.run)
+
+
+if __name__ == "__main__":
+    app()
+{% endif -%}

--- a/src/scaffoldkit/blueprints/cli-tool/templates/tests/__init__.py.j2
+++ b/src/scaffoldkit/blueprints/cli-tool/templates/tests/__init__.py.j2
@@ -1,0 +1,1 @@
+"""Test suite for {{ project_name }}."""

--- a/src/scaffoldkit/blueprints/cli-tool/templates/tests/test_run.py.j2
+++ b/src/scaffoldkit/blueprints/cli-tool/templates/tests/test_run.py.j2
@@ -1,0 +1,23 @@
+{% if cli_framework == "click" -%}
+"""Smoke test for the run command."""
+from click.testing import CliRunner
+
+from src.main import app
+
+
+def test_run_greets() -> None:
+    result = CliRunner().invoke(app, ["run", "--name", "scaffoldkit"])
+    assert result.exit_code == 0
+    assert "Hello, scaffoldkit!" in result.output
+{% else -%}
+"""Smoke test for the run command."""
+from typer.testing import CliRunner
+
+from src.main import app
+
+
+def test_run_greets() -> None:
+    result = CliRunner().invoke(app, ["run", "--name", "scaffoldkit"])
+    assert result.exit_code == 0
+    assert "Hello, scaffoldkit!" in result.stdout
+{% endif -%}

--- a/src/scaffoldkit/blueprints/rest-api/blueprint.yaml
+++ b/src/scaffoldkit/blueprints/rest-api/blueprint.yaml
@@ -102,6 +102,32 @@ templates:
   - source: README.md.j2
     target: README.md
 
+  # Minimal runnable FastAPI starter (entry module, one example route, smoke test)
+  # so a fastapi rest-api scaffold ships real source instead of an empty src/.
+  - source: src/__init__.py.j2
+    target: src/__init__.py
+    condition: is_fastapi
+
+  - source: src/main.py.j2
+    target: src/main.py
+    condition: is_fastapi
+
+  - source: src/routes/__init__.py.j2
+    target: src/routes/__init__.py
+    condition: is_fastapi
+
+  - source: src/routes/health.py.j2
+    target: src/routes/health.py
+    condition: is_fastapi
+
+  - source: tests/__init__.py.j2
+    target: tests/__init__.py
+    condition: is_fastapi
+
+  - source: tests/test_health.py.j2
+    target: tests/test_health.py
+    condition: is_fastapi
+
   - source: pyproject.toml.j2
     target: pyproject.toml
     condition: is_fastapi

--- a/src/scaffoldkit/blueprints/rest-api/templates/pyproject.toml.j2
+++ b/src/scaffoldkit/blueprints/rest-api/templates/pyproject.toml.j2
@@ -12,3 +12,6 @@ dependencies = [
   "fastapi>=0.115.12,<0.116.0",
   "uvicorn[standard]>=0.34.0,<0.35.0"
 ]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src"]

--- a/src/scaffoldkit/blueprints/rest-api/templates/src/__init__.py.j2
+++ b/src/scaffoldkit/blueprints/rest-api/templates/src/__init__.py.j2
@@ -1,0 +1,1 @@
+"""{{ display_name }} application package."""

--- a/src/scaffoldkit/blueprints/rest-api/templates/src/main.py.j2
+++ b/src/scaffoldkit/blueprints/rest-api/templates/src/main.py.j2
@@ -1,0 +1,18 @@
+"""{{ display_name }} - FastAPI application entry point.
+
+Run locally with:
+
+    uvicorn src.main:app --reload --port 8000
+"""
+from fastapi import FastAPI
+
+from src.routes import health
+
+app = FastAPI(title="{{ display_name }}", version="0.1.0")
+app.include_router(health.router)
+
+
+@app.get("/")
+def root() -> dict[str, str]:
+    """Return a small service descriptor for the API root."""
+    return {"service": "{{ project_name }}", "status": "ok"}

--- a/src/scaffoldkit/blueprints/rest-api/templates/src/routes/__init__.py.j2
+++ b/src/scaffoldkit/blueprints/rest-api/templates/src/routes/__init__.py.j2
@@ -1,0 +1,1 @@
+"""HTTP route handlers for {{ project_name }}."""

--- a/src/scaffoldkit/blueprints/rest-api/templates/src/routes/health.py.j2
+++ b/src/scaffoldkit/blueprints/rest-api/templates/src/routes/health.py.j2
@@ -1,0 +1,10 @@
+"""Health check route."""
+from fastapi import APIRouter
+
+router = APIRouter(tags=["health"])
+
+
+@router.get("/health")
+def health() -> dict[str, str]:
+    """Liveness probe used by orchestration and smoke tests."""
+    return {"status": "ok"}

--- a/src/scaffoldkit/blueprints/rest-api/templates/tests/__init__.py.j2
+++ b/src/scaffoldkit/blueprints/rest-api/templates/tests/__init__.py.j2
@@ -1,0 +1,1 @@
+"""Test suite for {{ project_name }}."""

--- a/src/scaffoldkit/blueprints/rest-api/templates/tests/test_health.py.j2
+++ b/src/scaffoldkit/blueprints/rest-api/templates/tests/test_health.py.j2
@@ -1,0 +1,12 @@
+"""Smoke tests for the health route and application wiring."""
+from src.main import app
+from src.routes.health import health
+
+
+def test_health_handler_returns_ok() -> None:
+    assert health() == {"status": "ok"}
+
+
+def test_app_registers_health_route() -> None:
+    paths = {getattr(route, "path", None) for route in app.routes}
+    assert "/health" in paths

--- a/tests/test_new_blueprints.py
+++ b/tests/test_new_blueprints.py
@@ -1,5 +1,6 @@
 """Tests for rest-api, cli-tool, and static-site blueprints."""
 
+import ast
 from pathlib import Path
 
 import pytest
@@ -155,6 +156,35 @@ class TestRestApiBlueprint:
         assert not (output / "docker-compose.yml").exists()
         assert not (output / ".github" / "workflows" / "ci.yml").exists()
 
+    def test_fastapi_includes_runnable_python_baseline(self, tmp_path: Path):
+        output = _generate(tmp_path, "rest-api", _REST_API_DEFAULTS)
+        main = output / "src" / "main.py"
+        route = output / "src" / "routes" / "health.py"
+        smoke = output / "tests" / "test_health.py"
+        assert main.exists()
+        assert route.exists()
+        assert smoke.exists()
+        # The rendered starter is valid Python, not just a docs/manifest skeleton.
+        for path in (
+            main,
+            route,
+            smoke,
+            output / "src" / "__init__.py",
+            output / "src" / "routes" / "__init__.py",
+        ):
+            ast.parse(path.read_text())
+        assert "FastAPI" in main.read_text()
+        assert "/health" in route.read_text()
+        # The flat src/ package must be buildable by hatchling.
+        pyproject = (output / "pyproject.toml").read_text()
+        assert "[tool.hatch.build.targets.wheel]" in pyproject
+        assert 'packages = ["src"]' in pyproject
+
+    def test_non_fastapi_framework_skips_python_baseline(self, tmp_path: Path):
+        output = _generate(tmp_path, "rest-api", {**_REST_API_DEFAULTS, "framework": "express"})
+        assert not (output / "src" / "main.py").exists()
+        assert not (output / "tests" / "test_health.py").exists()
+
 
 # ---------------------------------------------------------------------------
 # cli-tool blueprint
@@ -240,6 +270,32 @@ class TestCliToolBlueprint:
         assert (output / "src" / "commands" / "config.ts").exists()
         assert (output / "src" / "config" / "loader.ts").exists()
         assert (output / "tests" / "run.test.ts").exists()
+
+    def test_python_cli_includes_runnable_baseline(self, tmp_path: Path):
+        output = _generate(tmp_path, "cli-tool", _CLI_TOOL_DEFAULTS)
+        main = output / "src" / "main.py"
+        command = output / "src" / "commands" / "run.py"
+        smoke = output / "tests" / "test_run.py"
+        assert main.exists()
+        assert command.exists()
+        assert smoke.exists()
+        for path in (main, command, smoke):
+            ast.parse(path.read_text())
+        assert "typer" in main.read_text()
+        # A python cli must not also ship the TypeScript baseline.
+        assert not (output / "src" / "main.ts").exists()
+        # The flat src/ package must be buildable, and the console script name
+        # must match the README's hyphenated project name (not an underscored slug).
+        pyproject = (output / "pyproject.toml").read_text()
+        assert "[tool.hatch.build.targets.wheel]" in pyproject
+        assert 'packages = ["src"]' in pyproject
+        assert 'test-cli = "src.main:app"' in pyproject
+
+    def test_python_cli_supports_click_framework(self, tmp_path: Path):
+        output = _generate(tmp_path, "cli-tool", {**_CLI_TOOL_DEFAULTS, "cli_framework": "click"})
+        main = (output / "src" / "main.py").read_text()
+        ast.parse(main)
+        assert "click" in main
 
     def test_generates_ci_contract_when_enabled(self, tmp_path: Path):
         output = _generate(tmp_path, "cli-tool", _CLI_TOOL_DEFAULTS)


### PR DESCRIPTION
## What

The `rest-api` and `cli-tool` blueprints now emit a minimal, runnable source starter in the declared language instead of only manifests + docs.

## Why

r5 dogfood (dogfood-quicklinks-r5): a freshly generated `rest-api` repo had an empty `src/` (git drops it) yet was presented as a usable scaffold, and the `cli-tool`'s `[project.scripts] src.main:app` entry point referenced a module that did not exist. A fresh implementer had no real code to start from.

## Change

- **rest-api (fastapi):** `src/main.py` (FastAPI app exposing `GET /` and a `/health` router), `src/routes/health.py`, and a `tests/test_health.py` smoke test. Runs via `uvicorn src.main:app`.
- **cli-tool (python):** `src/main.py` (typer app, or a click group when `cli_framework=click`), `src/commands/run.py`, and a `tests/test_run.py` smoke test. A no-op typer callback keeps `run` a named subcommand.
- **pyproject:** add `[tool.hatch.build.targets.wheel] packages = ["src"]` to both so the flat `src/` layout builds (`pip install -e ".[dev]"` and the console script were broken without it), and align the console-script name with the README's hyphenated project name.

Templates are gated on `is_fastapi` / `is_python`, so they never leak into the remapped `fastapi-backend`/`django-drf` blueprints or the TypeScript cli path. The layouts match the language-aware feature task paths agent-planforge now generates (`src/routes/*.py`, `src/commands/*.py`).

## Verification

- 273 tests, ruff, ruff format, mypy all green.
- Generated cli-tool: `uv pip install -e ".[dev]"` succeeds and the installed console script runs (`log-tailer run --name Lan` produces `Hello, Lan!`); the smoke test passes.
- Generated rest-api: the FastAPI app constructs and `/health` returns `{"status": "ok"}`.
- 3-lens adversarial review: one must-fix (the hatchling wheel-target), applied and re-verified; remaining items are follow-ups.

## Scope / follow-ups

- Scoped to the default/shipping stacks (fastapi, python). The `express`/`django-rest`/`spring-boot` (rest-api) and `go`/`rust` (cli-tool) variants stay planning-baseline.
- The planforge remap target `fastapi-backend` still ships no `.py` source (a separate blueprint); follow-up.
- project-forge `readScaffoldPreview` "full scaffold" label honesty (cross-repo); follow-up.

Refs: agent-tasks 6fafaaad