### PR TITLE
feat(fastapi-backend): emit a minimal runnable FastAPI starter

### DIFF
--- a/src/scaffoldkit/blueprints/fastapi-backend/blueprint.yaml
+++ b/src/scaffoldkit/blueprints/fastapi-backend/blueprint.yaml
@@ -116,6 +116,31 @@ templates:
   - source: requirements-dev.txt.j2
     target: requirements-dev.txt
 
+  # Minimal runnable FastAPI starter so the blueprint emits real source, not just
+  # empty app/ directories. Unconditional: fastapi-backend is always FastAPI (it has
+  # no `framework` variable, so the rest-api blueprint's is_fastapi gate does not
+  # apply here). Runs via `uvicorn app.main:app` (pyproject sets pythonpath = ["."]).
+  - source: app/__init__.py.j2
+    target: app/__init__.py
+
+  - source: app/main.py.j2
+    target: app/main.py
+
+  - source: app/api/__init__.py.j2
+    target: app/api/__init__.py
+
+  - source: app/api/routes/__init__.py.j2
+    target: app/api/routes/__init__.py
+
+  - source: app/api/routes/health.py.j2
+    target: app/api/routes/health.py
+
+  - source: tests/__init__.py.j2
+    target: tests/__init__.py
+
+  - source: tests/test_health.py.j2
+    target: tests/test_health.py
+
   - source: .dockerignore.j2
     target: .dockerignore
     condition: use_docker

--- a/src/scaffoldkit/blueprints/fastapi-backend/templates/app/__init__.py.j2
+++ b/src/scaffoldkit/blueprints/fastapi-backend/templates/app/__init__.py.j2
@@ -1,0 +1,1 @@
+"""{{ display_name }} application package."""

--- a/src/scaffoldkit/blueprints/fastapi-backend/templates/app/api/__init__.py.j2
+++ b/src/scaffoldkit/blueprints/fastapi-backend/templates/app/api/__init__.py.j2
@@ -1,0 +1,1 @@
+"""API layer: FastAPI routers and HTTP wiring for {{ project_name }}."""

--- a/src/scaffoldkit/blueprints/fastapi-backend/templates/app/api/routes/__init__.py.j2
+++ b/src/scaffoldkit/blueprints/fastapi-backend/templates/app/api/routes/__init__.py.j2
@@ -1,0 +1,1 @@
+"""HTTP route handlers for {{ project_name }}."""

--- a/src/scaffoldkit/blueprints/fastapi-backend/templates/app/api/routes/health.py.j2
+++ b/src/scaffoldkit/blueprints/fastapi-backend/templates/app/api/routes/health.py.j2
@@ -1,0 +1,10 @@
+"""Health check route."""
+from fastapi import APIRouter
+
+router = APIRouter(tags=["health"])
+
+
+@router.get("/health")
+def health() -> dict[str, str]:
+    """Liveness probe used by orchestration and smoke tests."""
+    return {"status": "ok"}

--- a/src/scaffoldkit/blueprints/fastapi-backend/templates/app/main.py.j2
+++ b/src/scaffoldkit/blueprints/fastapi-backend/templates/app/main.py.j2
@@ -1,0 +1,18 @@
+"""{{ display_name }} - FastAPI application entry point.
+
+Run locally with:
+
+    uvicorn app.main:app --reload --port 8000
+"""
+from fastapi import FastAPI
+
+from app.api.routes import health
+
+app = FastAPI(title="{{ display_name }}", version="0.1.0")
+app.include_router(health.router)
+
+
+@app.get("/")
+def root() -> dict[str, str]:
+    """Return a small service descriptor for the API root."""
+    return {"service": "{{ project_name }}", "status": "ok"}

--- a/src/scaffoldkit/blueprints/fastapi-backend/templates/tests/__init__.py.j2
+++ b/src/scaffoldkit/blueprints/fastapi-backend/templates/tests/__init__.py.j2
@@ -1,0 +1,1 @@
+"""Test suite for {{ display_name }}."""

--- a/src/scaffoldkit/blueprints/fastapi-backend/templates/tests/test_health.py.j2
+++ b/src/scaffoldkit/blueprints/fastapi-backend/templates/tests/test_health.py.j2
@@ -1,0 +1,12 @@
+"""Smoke tests for the health route and application wiring."""
+from app.main import app
+from app.api.routes.health import health
+
+
+def test_health_handler_returns_ok() -> None:
+    assert health() == {"status": "ok"}
+
+
+def test_app_registers_health_route() -> None:
+    paths = {getattr(route, "path", None) for route in app.routes}
+    assert "/health" in paths

--- a/tests/test_blueprint_contract_audit.py
+++ b/tests/test_blueprint_contract_audit.py
@@ -18,7 +18,12 @@ _PRIMARY_MANIFEST_CONTRACTS = {
     "cli-tool": ("Cargo.toml", "go.mod", "package.json", "pyproject.toml"),
     "django-drf": ("pyproject.toml", "requirements.txt", "requirements-dev.txt"),
     "express-api": ("package.json", "tsconfig.json"),
-    "fastapi-backend": ("pyproject.toml", "requirements.txt", "requirements-dev.txt"),
+    "fastapi-backend": (
+        "pyproject.toml",
+        "requirements.txt",
+        "requirements-dev.txt",
+        "app/main.py",
+    ),
     "nextjs-frontend": ("package.json",),
     "nextjs-fullstack": ("package.json",),
     "reference-php-app": ("tools/composer.json",),

--- a/tests/test_python_api_blueprints.py
+++ b/tests/test_python_api_blueprints.py
@@ -1,5 +1,6 @@
 """Tests for FastAPI and Django DRF blueprints."""
 
+import ast
 from pathlib import Path
 
 import pytest
@@ -67,6 +68,37 @@ class TestFastapiBackendBlueprint:
         assert (output / "app" / "repositories").is_dir()
         assert (output / "alembic" / "versions").is_dir()
         assert (output / "tests" / "integration").is_dir()
+
+    def test_emits_runnable_python_source(self, tmp_path: Path):
+        output = _generate(tmp_path, "fastapi-backend", _FASTAPI_DEFAULTS)
+        main = output / "app" / "main.py"
+        route = output / "app" / "api" / "routes" / "health.py"
+        smoke = output / "tests" / "test_health.py"
+        assert main.exists()
+        assert route.exists()
+        assert smoke.exists()
+        # The rendered starter is valid Python, not just empty app/ directories.
+        for path in (
+            main,
+            route,
+            smoke,
+            output / "app" / "__init__.py",
+            output / "app" / "api" / "__init__.py",
+            output / "app" / "api" / "routes" / "__init__.py",
+            output / "tests" / "__init__.py",
+        ):
+            ast.parse(path.read_text())
+        assert "FastAPI" in main.read_text()
+        assert "app.api.routes" in main.read_text()
+        assert "/health" in route.read_text()
+        # ast.parse accepts unrendered Jinja inside string literals (docstrings,
+        # title="{{ display_name }}"), so guard substitution explicitly.
+        assert "{{" not in main.read_text()
+        assert "{{" not in route.read_text()
+        assert "Test FastAPI Service" in main.read_text()
+        # The app/ package runs via `uvicorn app.main:app` (pyproject sets
+        # pythonpath = ["."] / package = false, so no wheel build is needed).
+        assert "app.main:app" in (output / "README.md").read_text()
 
     @pytest.mark.parametrize("auth_strategy", ["jwt", "oauth2", "api-key", "none"])
     def test_all_auth_strategies(self, tmp_path: Path, auth_strategy: str):


### PR DESCRIPTION
## Problem

The `fastapi-backend` blueprint declared an `app/` package layout as empty directories but shipped zero Python source. A python/fastapi-hinted REST intake that planforge remaps to `fastapi-backend` therefore produced an empty scaffold, the same gap #48 fixed for the thin `rest-api` and `cli-tool` blueprints.

## Change

- 7 unconditional `.j2` templates under `fastapi-backend/templates/`: `app/main.py` (FastAPI app + root + `/health` router), `app/api/routes/health.py` (APIRouter), the package `__init__.py` files, and `tests/test_health.py`.
- Unconditional because fastapi-backend is always FastAPI (no `framework` variable, so the rest-api `is_fastapi` gate does not apply here).
- Runs via `uvicorn app.main:app`. No pyproject change is needed: the blueprint sets `pythonpath = ["."]` / `package = false`, unlike #48's thin rest-api which builds a wheel.
- `app/main.py` added to the contract audit so the source stays enforced; a new test generates the blueprint, ast.parses the source, and guards Jinja substitution.

## Scope

`django-drf` has the same empty-source gap (the other planforge remap target) and is filed as a separate follow-up.

## Verification

`pytest` 274 passed (incl. the new `test_emits_runnable_python_source`), `ruff check .` clean, `mypy src/scaffoldkit/` clean. Manual generation confirmed the rendered `app/main.py` substitutes variables with no template-marker leakage. Review subagent: SHIP, no must-fix.

Refs: agent-tasks e3cf37c2