### PR TITLE
chore(release): scaffoldkit v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-06-01
+
+### Added
+
+- Minimal runnable starter source for the `rest-api` (FastAPI) and `cli-tool` (Python) blueprints, so a generated repo opens with real, runnable code and a smoke test instead of an empty `src/` ([#48](https://github.com/LanNguyenSi/scaffoldkit/pull/48))
+- Minimal runnable FastAPI starter for the `fastapi-backend` blueprint, the planforge remap target for python/FastAPI REST intakes ([#49](https://github.com/LanNguyenSi/scaffoldkit/pull/49))
+
+### Changed
+
+- Unified the `fastapi-backend` blueprint on the `src/` layout (`app/` to `src/`, `app/api/routes/` to `src/routes/`) so its scaffold matches the planner's generated task paths and the thin `rest-api` blueprint ([#50](https://github.com/LanNguyenSi/scaffoldkit/pull/50))
+
 ## [0.2.0] - 2026-06-01
 
 ### Added
@@ -90,6 +101,7 @@ A `Dockerfile` and `docker-compose.yml` are shipped for the Docker path.
 - Single-user local execution; no concurrency guards.
 - Blueprint variables are flat (no nested objects).
 
-[Unreleased]: https://github.com/LanNguyenSi/scaffoldkit/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/LanNguyenSi/scaffoldkit/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/LanNguyenSi/scaffoldkit/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/LanNguyenSi/scaffoldkit/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/LanNguyenSi/scaffoldkit/releases/tag/v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scaffoldkit"
-version = "0.2.0"
+version = "0.3.0"
 description = "AI-aided project scaffolding tool with declarative blueprints"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/scaffoldkit/__init__.py
+++ b/src/scaffoldkit/__init__.py
@@ -1,3 +1,3 @@
 """ScaffoldKit - AI-aided project scaffolding tool."""
 
-__version__ = "0.1.0"
+__version__ = "0.3.0"


### PR DESCRIPTION
Cut scaffoldkit **v0.3.0** (from v0.2.0).

## Changes since v0.2.0

- **Added** runnable starter source for the `rest-api` (FastAPI) and `cli-tool` (Python) blueprints ([#48](https://github.com/LanNguyenSi/scaffoldkit/pull/48))
- **Added** a minimal runnable FastAPI starter for the `fastapi-backend` blueprint ([#49](https://github.com/LanNguyenSi/scaffoldkit/pull/49))
- **Changed** the `fastapi-backend` blueprint to the `src/` layout so its scaffold matches the planner's task paths and the thin `rest-api` blueprint ([#50](https://github.com/LanNguyenSi/scaffoldkit/pull/50))

Version bumped in `pyproject.toml` (and the stale `__init__.py` `__version__` aligned). CHANGELOG `[0.3.0]` section + footer links added.

## Verification

`pytest` 274 passed, `ruff` clean, `mypy` clean. Dogfooded end-to-end on the live stack (r6/r7/r8 generated repos, fresh-implementer `canMakeProgress=true`). Review subagent: SHIP (one CHANGELOG footer-link fix applied).

Tagging `v0.3.0` after merge triggers the release workflow (CI + GitHub Release).

Refs: agent-tasks 6d579e60