### PR TITLE
fix(symfony-backend): correct PSR-4 escaping, allow symfony/runtime, add smoke test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dev = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/scaffoldkit"]
+exclude = ["src/scaffoldkit/blueprints/**"]
 
 [tool.hatch.build.targets.wheel.force-include]
 "src/scaffoldkit/blueprints" = "scaffoldkit/blueprints"

--- a/src/scaffoldkit/blueprints/symfony-backend/blueprint.yaml
+++ b/src/scaffoldkit/blueprints/symfony-backend/blueprint.yaml
@@ -196,6 +196,12 @@ templates:
     target: AI_CONTEXT.md
     condition: ai_context
 
+  - source: phpunit.dist.xml.j2
+    target: phpunit.dist.xml
+
+  - source: tests/Unit/Controller/HealthControllerTest.php.j2
+    target: tests/Unit/Controller/HealthControllerTest.php
+
 static_files:
   - source: .editorconfig
     target: .editorconfig

--- a/src/scaffoldkit/blueprints/symfony-backend/templates/composer.json.j2
+++ b/src/scaffoldkit/blueprints/symfony-backend/templates/composer.json.j2
@@ -33,18 +33,19 @@
     "symfony/debug-bundle": "{{ symfony_version }}.*",
     "symfony/maker-bundle": "^1.61",
     "symfony/phpunit-bridge": "{{ symfony_version }}.*",
+    "phpunit/phpunit": "^11.5",
     "symfony/web-profiler-bundle": "{{ symfony_version }}.*"{% if test_strategy == "pest" %},
     "pestphp/pest": "^3.8"{% elif test_strategy == "phpunit-and-behat" %},
     "behat/behat": "^3.17"{% endif %}
   },
   "autoload": {
     "psr-4": {
-      "App\\\\": "src/"
+      "App\\": "src/"
     }
   },
   "autoload-dev": {
     "psr-4": {
-      "App\\\\Tests\\\\": "tests/"
+      "App\\Tests\\": "tests/"
     }
   },
   "scripts": {
@@ -66,7 +67,8 @@
   "config": {
     "allow-plugins": {
       "php-http/discovery": true,
-      "symfony/flex": true
+      "symfony/flex": true,
+      "symfony/runtime": true
     },
     "sort-packages": true
   },

--- a/src/scaffoldkit/blueprints/symfony-backend/templates/phpunit.dist.xml.j2
+++ b/src/scaffoldkit/blueprints/symfony-backend/templates/phpunit.dist.xml.j2
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheDirectory=".phpunit.cache">
+    <php>
+        <ini name="display_errors" value="1" />
+        <ini name="error_reporting" value="-1" />
+        <server name="APP_ENV" value="test" force="true" />
+        <server name="SHELL_VERBOSITY" value="-1" />
+    </php>
+    <testsuites>
+        <testsuite name="{{ project_name }} Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/src/scaffoldkit/blueprints/symfony-backend/templates/tests/Unit/Controller/HealthControllerTest.php.j2
+++ b/src/scaffoldkit/blueprints/symfony-backend/templates/tests/Unit/Controller/HealthControllerTest.php.j2
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Controller;
+
+use App\Controller\HealthController;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+final class HealthControllerTest extends TestCase
+{
+    public function testHealthEndpointReturnsOkStatus(): void
+    {
+        $response = (new HealthController())();
+
+        self::assertInstanceOf(JsonResponse::class, $response);
+        self::assertSame(200, $response->getStatusCode());
+
+        $payload = json_decode((string) $response->getContent(), true);
+        self::assertSame('ok', $payload['status']);
+        self::assertSame('{{ project_name }}', $payload['service']);
+    }
+}

--- a/tests/test_symfony_backend_blueprint.py
+++ b/tests/test_symfony_backend_blueprint.py
@@ -75,3 +75,25 @@ class TestSymfonyBackendBlueprint:
         assert not (output / ".dockerignore").exists()
         assert not (output / "docker" / "php" / "Dockerfile").exists()
         assert not (output / ".github" / "workflows" / "ci.yml").exists()
+
+    def test_composer_autoload_and_runtime_plugin_are_correct(self, tmp_path: Path):
+        import json
+
+        output = _generate(tmp_path, _DEFAULTS)
+        composer = json.loads((output / "composer.json").read_text())
+
+        # PSR-4 prefix must be a single namespace separator. Regression: the
+        # template double-escaped it to "App\\\\" which Composer reads as a
+        # double separator, so autoload resolves nothing (ClassNotFoundError).
+        assert composer["autoload"]["psr-4"] == {"App\\": "src/"}
+        assert composer["autoload-dev"]["psr-4"] == {"App\\Tests\\": "tests/"}
+
+        # symfony/runtime ships a Composer plugin generating
+        # vendor/autoload_runtime.php (required by public/index.php + bin/console);
+        # it must be allow-listed or Composer 2.2+ blocks it.
+        assert composer["config"]["allow-plugins"].get("symfony/runtime") is True
+
+        # A runnable smoke test + its phpunit config ship with the scaffold.
+        assert "phpunit/phpunit" in composer["require-dev"]
+        assert (output / "phpunit.dist.xml").exists()
+        assert (output / "tests" / "Unit" / "Controller" / "HealthControllerTest.php").exists()


### PR DESCRIPTION
## What
The `symfony-backend` blueprint generated a project that could not boot:
- `composer.json.j2` double-escaped the PSR-4 prefix to four backslashes, so Composer read a double namespace separator and autoload resolved nothing (ClassNotFoundError).
- `symfony/runtime` was missing from `config.allow-plugins`; Composer 2.2+ blocks the plugin that generates `vendor/autoload_runtime.php`, which `public/index.php` and `bin/console` require.

## Fix
- Single-separator PSR-4 for `autoload` and `autoload-dev`.
- Allow-list `symfony/runtime`.
- Ship a runnable `HealthController` unit test plus `phpunit.dist.xml` and the `phpunit/phpunit` dev dependency, so a fresh project has a green smoke test that meets the Phase-3 starter-code bar.
- Regression test asserts the rendered `composer.json` autoload and allow-plugins.

## Verification
- `pytest tests/test_symfony_backend_blueprint.py tests/test_company_blueprints.py` (58 passed).
- Rendered project: correct single-separator PSR-4, allow-plugins includes symfony/runtime, `composer validate` valid, `php -l` clean on all generated PHP.
- Local PHP is 8.1 (blueprint targets 8.2+/Symfony 7.2), so the PHPUnit 11 suite was not run end-to-end; the unit test is pure (no kernel or DB), depending only on autoload.

Refs: PHASE3_LANE_A_REPORT_2026-06-02.md