### PR TITLE
feat(express-api): emit runnable Express starter + smoke test

### DIFF
--- a/src/scaffoldkit/blueprints/express-api/blueprint.yaml
+++ b/src/scaffoldkit/blueprints/express-api/blueprint.yaml
@@ -81,6 +81,24 @@ templates:
   - source: tsconfig.json.j2
     target: tsconfig.json
 
+  - source: .env.example.j2
+    target: .env.example
+
+  - source: src/index.ts.j2
+    target: src/index.ts
+
+  - source: src/routes/health.ts.j2
+    target: src/routes/health.ts
+
+  - source: src/middleware/error.ts.j2
+    target: src/middleware/error.ts
+
+  - source: prisma/schema.prisma.j2
+    target: prisma/schema.prisma
+
+  - source: tests/health.test.ts.j2
+    target: tests/health.test.ts
+
   - source: Makefile.j2
     target: Makefile
 

--- a/src/scaffoldkit/blueprints/express-api/templates/.env.example.j2
+++ b/src/scaffoldkit/blueprints/express-api/templates/.env.example.j2
@@ -1,0 +1,20 @@
+# Copy to .env and adjust for your environment.
+
+# HTTP port the Express server binds to.
+PORT=3000
+
+# Prisma database connection string.
+{% if db_provider == "postgresql" -%}
+DATABASE_URL="postgresql://{{ project_name }}:{{ project_name }}@localhost:5432/{{ project_name }}?schema=public"
+{% elif db_provider == "mysql" -%}
+DATABASE_URL="mysql://{{ project_name }}:{{ project_name }}@localhost:3306/{{ project_name }}"
+{% else -%}
+DATABASE_URL="file:./dev.db"
+{% endif -%}
+{% if auth_strategy == "jwt" %}
+# Secret used to sign JWT access tokens.
+JWT_SECRET="change-me"
+{% endif -%}
+{% if use_redis or use_queue %}
+REDIS_URL="redis://localhost:6379"
+{% endif -%}

--- a/src/scaffoldkit/blueprints/express-api/templates/package.json.j2
+++ b/src/scaffoldkit/blueprints/express-api/templates/package.json.j2
@@ -2,18 +2,22 @@
   "name": "{{ project_name }}",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "description": "{{ description }}",
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "tsc -p tsconfig.json",
     "start": "node dist/index.js",
-    "test": "node --test",
-    "lint": "tsc --noEmit"
+    "test": "node --import tsx --test \"tests/**/*.test.ts\"",
+    "lint": "tsc --noEmit",
+    "prisma:generate": "prisma generate",
+    "prisma:migrate": "prisma migrate dev"
   },
   "engines": {
     "node": ">=20"
   },
   "dependencies": {
+    "@prisma/client": "^6.5.0",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
 {% if auth_strategy == "jwt" -%}
@@ -38,6 +42,7 @@
 {% if auth_strategy == "jwt" -%}
     "@types/jsonwebtoken": "^9.0.9",
 {% endif -%}
+    "prisma": "^6.5.0",
     "tsx": "^4.19.3",
     "typescript": "^5.8.2"
   }

--- a/src/scaffoldkit/blueprints/express-api/templates/prisma/schema.prisma.j2
+++ b/src/scaffoldkit/blueprints/express-api/templates/prisma/schema.prisma.j2
@@ -1,0 +1,23 @@
+// Prisma schema for {{ display_name }}.
+// Docs: https://www.prisma.io/docs/concepts/components/prisma-schema
+//
+// After editing this file run:
+//   npx prisma migrate dev --name <description>
+//   npx prisma generate
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "{{ db_provider }}"
+  url      = env("DATABASE_URL")
+}
+
+/// Example model. Replace with your own domain models.
+model Example {
+  id        String   @id @default(cuid())
+  name      String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}

--- a/src/scaffoldkit/blueprints/express-api/templates/src/index.ts.j2
+++ b/src/scaffoldkit/blueprints/express-api/templates/src/index.ts.j2
@@ -1,0 +1,46 @@
+import express, { type Express } from "express";
+import { healthRouter } from "./routes/health.js";
+import { errorHandler } from "./middleware/error.js";
+
+/**
+ * Build and configure the Express application.
+ *
+ * Routers mount here; business logic lives in `src/services/` and data
+ * access in Prisma. The error handler is registered last so it catches
+ * failures from every route.
+ */
+export function createApp(): Express {
+  const app = express();
+
+  app.use(express.json());
+
+  app.use("/health", healthRouter);
+
+  // Error-handling middleware must be the last `app.use` call.
+  app.use(errorHandler);
+
+  return app;
+}
+
+const app = createApp();
+
+// Start the server only when this module is the entry point, so tests can
+// import `createApp` without binding a port.
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  const port = Number(process.env.PORT ?? 3000);
+  const server = app.listen(port, () => {
+    // eslint-disable-next-line no-console
+    console.log(`{{ display_name }} listening on http://localhost:${port}`);
+  });
+
+  // Graceful shutdown: stop accepting connections, then exit.
+  const shutdown = (signal: string) => {
+    // eslint-disable-next-line no-console
+    console.log(`Received ${signal}, shutting down.`);
+    server.close(() => process.exit(0));
+  };
+  process.on("SIGTERM", () => shutdown("SIGTERM"));
+  process.on("SIGINT", () => shutdown("SIGINT"));
+}
+
+export { app };

--- a/src/scaffoldkit/blueprints/express-api/templates/src/middleware/error.ts.j2
+++ b/src/scaffoldkit/blueprints/express-api/templates/src/middleware/error.ts.j2
@@ -1,0 +1,26 @@
+import type { NextFunction, Request, Response } from "express";
+
+/**
+ * Global error-handling middleware.
+ *
+ * Registered last in `src/index.ts`. Express recognises an error handler by
+ * its four-argument signature. Never leak internal error details to clients
+ * in production; log them server-side instead.
+ */
+export function errorHandler(
+  err: unknown,
+  _req: Request,
+  res: Response,
+  // `next` is required for Express to treat this as an error handler.
+  _next: NextFunction,
+): void {
+  // eslint-disable-next-line no-console
+  console.error(err);
+
+  const status =
+    typeof err === "object" && err !== null && "status" in err && typeof err.status === "number"
+      ? err.status
+      : 500;
+
+  res.status(status).json({ error: status === 500 ? "Internal Server Error" : String(err) });
+}

--- a/src/scaffoldkit/blueprints/express-api/templates/src/routes/health.ts.j2
+++ b/src/scaffoldkit/blueprints/express-api/templates/src/routes/health.ts.j2
@@ -1,0 +1,14 @@
+import { Router, type Request, type Response } from "express";
+
+/**
+ * Health-check router.
+ *
+ * Example route demonstrating the routes -> response layering. Real routes
+ * should delegate to a service in `src/services/` rather than computing the
+ * response inline.
+ */
+export const healthRouter = Router();
+
+healthRouter.get("/", (_req: Request, res: Response) => {
+  res.json({ status: "ok" });
+});

--- a/src/scaffoldkit/blueprints/express-api/templates/tests/health.test.ts.j2
+++ b/src/scaffoldkit/blueprints/express-api/templates/tests/health.test.ts.j2
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { after, before, test } from "node:test";
+import type { AddressInfo } from "node:net";
+import type { Server } from "node:http";
+import { createApp } from "../src/index.js";
+
+/**
+ * Smoke test for the health route.
+ *
+ * Boots the real Express app on an ephemeral port (no live database needed)
+ * and asserts GET /health returns { status: "ok" }. This is the baseline a
+ * fresh implementer extends with route-level tests.
+ */
+let server: Server;
+let baseUrl: string;
+
+before(async () => {
+  const app = createApp();
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, () => {
+      const { port } = server.address() as AddressInfo;
+      baseUrl = `http://127.0.0.1:${port}`;
+      resolve();
+    });
+  });
+});
+
+after(async () => {
+  await new Promise<void>((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+});
+
+test("GET /health returns status ok", async () => {
+  const res = await fetch(`${baseUrl}/health`);
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as { status: string };
+  assert.deepEqual(body, { status: "ok" });
+});

--- a/src/scaffoldkit/blueprints/express-api/templates/tsconfig.json.j2
+++ b/src/scaffoldkit/blueprints/express-api/templates/tsconfig.json.j2
@@ -10,5 +10,5 @@
     "skipLibCheck": true,
     "resolveJsonModule": true
   },
-  "include": ["src/**/*.ts", "tests/**/*.ts"]
+  "include": ["src/**/*.ts"]
 }

--- a/tests/test_express_api_starter.py
+++ b/tests/test_express_api_starter.py
@@ -1,0 +1,99 @@
+"""Tests for the express-api blueprint runnable starter code."""
+
+from pathlib import Path
+
+from scaffoldkit.blueprint_loader import load_blueprint
+from scaffoldkit.generator import generate
+from scaffoldkit.models import GenerationContext
+
+BLUEPRINTS_DIR = Path(__file__).resolve().parent.parent / "src" / "scaffoldkit" / "blueprints"
+
+_DEFAULTS = {
+    "project_name": "my-api",
+    "display_name": "My API",
+    "description": "A TypeScript REST API",
+    "db_provider": "postgresql",
+    "auth_strategy": "jwt",
+    "use_docker": True,
+    "use_redis": False,
+    "use_websockets": False,
+    "use_queue": False,
+    "ai_context": True,
+}
+
+
+def _generate(tmp_path: Path, variables: dict) -> Path:
+    bp_path = BLUEPRINTS_DIR / "express-api"
+    bp = load_blueprint(bp_path)
+    output = tmp_path / "output"
+    ctx = GenerationContext(
+        blueprint=bp,
+        blueprint_path=bp_path,
+        variables=variables,
+        target_dir=output,
+    )
+    result = generate(ctx)
+    assert result.success, f"Generation failed: {result.errors}"
+    return output
+
+
+def _assert_non_empty(path: Path) -> None:
+    assert path.exists(), f"expected file missing: {path}"
+    assert path.read_text().strip(), f"expected non-empty file: {path}"
+
+
+class TestExpressApiStarter:
+    def test_emits_runnable_source_files(self, tmp_path: Path):
+        output = _generate(tmp_path, _DEFAULTS)
+
+        # The starter source the implementer builds on. Before this change the
+        # src/ tree was empty and tsc failed with TS18003 (no inputs).
+        _assert_non_empty(output / "src" / "index.ts")
+        _assert_non_empty(output / "src" / "routes" / "health.ts")
+        _assert_non_empty(output / "src" / "middleware" / "error.ts")
+        _assert_non_empty(output / "prisma" / "schema.prisma")
+        _assert_non_empty(output / "tests" / "health.test.ts")
+        _assert_non_empty(output / ".env.example")
+
+    def test_entry_point_wires_router_and_error_handler(self, tmp_path: Path):
+        output = _generate(tmp_path, _DEFAULTS)
+        index = (output / "src" / "index.ts").read_text()
+
+        # Entry point must export an app factory, mount the health router,
+        # register the error handler, and listen on PORT (default 3000).
+        assert "export function createApp" in index
+        assert "healthRouter" in index
+        assert "errorHandler" in index
+        assert "process.env.PORT" in index
+
+    def test_health_route_returns_status_ok(self, tmp_path: Path):
+        output = _generate(tmp_path, _DEFAULTS)
+        route = (output / "src" / "routes" / "health.ts").read_text()
+
+        assert "healthRouter" in route
+        assert '{ status: "ok" }' in route
+
+    def test_prisma_schema_uses_selected_provider(self, tmp_path: Path):
+        output = _generate(tmp_path, _DEFAULTS)
+        schema = (output / "prisma" / "schema.prisma").read_text()
+
+        assert 'provider = "postgresql"' in schema
+        assert 'url      = env("DATABASE_URL")' in schema
+        assert "generator client" in schema
+        assert "model Example" in schema
+
+        # The provider tracks the db_provider variable so `prisma generate` works.
+        sqlite_output = _generate(tmp_path / "sqlite", {**_DEFAULTS, "db_provider": "sqlite"})
+        sqlite_schema = (sqlite_output / "prisma" / "schema.prisma").read_text()
+        assert 'provider = "sqlite"' in sqlite_schema
+
+    def test_smoke_test_uses_declared_node_test_runner(self, tmp_path: Path):
+        output = _generate(tmp_path, _DEFAULTS)
+        test_file = (output / "tests" / "health.test.ts").read_text()
+        package_json = (output / "package.json").read_text()
+
+        # Smoke test runs under Node's built-in test runner (the declared
+        # runner), loaded via the tsx devDep so TS test files execute.
+        assert 'from "node:test"' in test_file
+        assert "GET /health returns status ok" in test_file
+        assert "node --import tsx --test" in package_json


### PR DESCRIPTION
## What
The `express-api` blueprint emitted empty `src/` (tsc failed TS18003, canMakeProgress=false).

## Fix
Emit a runnable Express starter: `src/index.ts` (app + listen), `src/routes/health.ts`, `src/middleware/error.ts`, `prisma/schema.prisma`, `.env.example`, and a smoke test using the blueprint's declared `node --import tsx --test` runner. Narrows tsconfig include and adds `type: module` so the ESM entry builds. Adds a per-blueprint regression test.

## Verification
Render + `npm run build` (tsc exit 0, no TS18003) + `npm test` (health route ok) + `npx prisma generate` + scaffoldkit pytest (280 pass) + `uv build` (wheel, no collision). Rigorous review subagent: SHIP, 0 must-fix.

Refs: PHASE3_LANE_A_REPORT_2026-06-02.md