### PR TITLE
feat(nextjs-frontend): emit runnable app-router starter + smoke test

### DIFF
--- a/src/scaffoldkit/blueprints/nextjs-frontend/blueprint.yaml
+++ b/src/scaffoldkit/blueprints/nextjs-frontend/blueprint.yaml
@@ -170,6 +170,43 @@ templates:
     target: tsconfig.json
     condition: is_typescript
 
+  # --- Runnable app-router starter (App Router is the blueprint default) ---
+  - source: src/app/layout.tsx.j2
+    target: src/app/layout.tsx
+    condition: is_typescript
+
+  - source: src/app/page.tsx.j2
+    target: src/app/page.tsx
+    condition: is_typescript
+
+  - source: src/app/globals.css.j2
+    target: src/app/globals.css
+
+  - source: src/components/features/WelcomeCard.tsx.j2
+    target: src/components/features/WelcomeCard.tsx
+    condition: is_typescript
+
+  # --- Tailwind config (only when Tailwind is the styling choice) ---
+  - source: tailwind.config.ts.j2
+    target: tailwind.config.ts
+    condition: is_typescript
+
+  - source: postcss.config.mjs.j2
+    target: postcss.config.mjs
+
+  # --- Smoke test + runner config (vitest is the default runner) ---
+  - source: src/app/page.test.tsx.j2
+    target: src/app/page.test.tsx
+    condition: is_typescript
+
+  - source: vitest.config.ts.j2
+    target: vitest.config.ts
+    condition: is_typescript
+
+  - source: vitest.setup.ts.j2
+    target: vitest.setup.ts
+    condition: is_typescript
+
   - source: .dockerignore.j2
     target: .dockerignore
     condition: use_docker

--- a/src/scaffoldkit/blueprints/nextjs-frontend/templates/package.json.j2
+++ b/src/scaffoldkit/blueprints/nextjs-frontend/templates/package.json.j2
@@ -2,7 +2,6 @@
   "name": "{{ project_name }}",
   "version": "0.1.0",
   "private": true,
-  "packageManager": "pnpm@9.15.0",
   "scripts": {
     "dev": "next dev",
     "build": "next build",
@@ -30,7 +29,7 @@
     "clean": "rimraf .next out coverage"
   },
   "dependencies": {
-    "next": "{{ '15.2.4' if nextjs_version == '15' else '14.2.24' }}",
+    "next": "{{ '15.5.19' if nextjs_version == '15' else '14.2.35' }}",
     "react": "{{ '^19.0.0' if nextjs_version == '15' else '^18.3.1' }}",
     "react-dom": "{{ '^19.0.0' if nextjs_version == '15' else '^18.3.1' }}"{% if api_client == "axios" %},
     "axios": "^1.8.4"{% elif api_client == "tanstack-query" %},
@@ -50,14 +49,24 @@
     "@types/react": "{{ '^19.0.10' if nextjs_version == '15' else '^18.3.12' }}",
     "@types/react-dom": "{{ '^19.0.4' if nextjs_version == '15' else '^18.3.1' }}",
     "eslint": "^9.22.0",
-    "eslint-config-next": "{{ '15.2.4' if nextjs_version == '15' else '14.2.24' }}",
+    "eslint-config-next": "{{ '15.5.19' if nextjs_version == '15' else '14.2.35' }}",
+{% if styling == "tailwind" -%}
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.5.3",
+    "tailwindcss": "^3.4.17",
+{% endif -%}
 {% if language == "typescript" -%}
     "typescript": "^5.8.2",
 {% endif -%}
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.2.0",
 {% if test_strategy == "vitest-only" or test_strategy == "vitest-and-playwright" -%}
+    "@vitejs/plugin-react": "^4.3.4",
+    "jsdom": "^25.0.1",
     "vitest": "^3.0.9",
 {% else -%}
     "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
 {% endif -%}
 {% if test_strategy == "vitest-and-playwright" -%}
     "@playwright/test": "^1.51.0",

--- a/src/scaffoldkit/blueprints/nextjs-frontend/templates/postcss.config.mjs.j2
+++ b/src/scaffoldkit/blueprints/nextjs-frontend/templates/postcss.config.mjs.j2
@@ -1,0 +1,9 @@
+/** @type {import('postcss-load-config').Config} */
+const config = {
+  plugins: {
+{% if styling == "tailwind" %}    tailwindcss: {},
+    autoprefixer: {},
+{% endif %}  },
+};
+
+export default config;

--- a/src/scaffoldkit/blueprints/nextjs-frontend/templates/src/app/globals.css.j2
+++ b/src/scaffoldkit/blueprints/nextjs-frontend/templates/src/app/globals.css.j2
@@ -1,0 +1,33 @@
+{% if styling == "tailwind" -%}
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --background: #ffffff;
+  --foreground: #0a0a0a;
+  --card: #ffffff;
+  --muted-foreground: #6b7280;
+}
+
+body {
+  background: var(--background);
+  color: var(--foreground);
+}
+{%- else -%}
+:root {
+  --background: #ffffff;
+  --foreground: #0a0a0a;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--background);
+  color: var(--foreground);
+  font-family: system-ui, -apple-system, sans-serif;
+}
+{%- endif %}

--- a/src/scaffoldkit/blueprints/nextjs-frontend/templates/src/app/layout.tsx.j2
+++ b/src/scaffoldkit/blueprints/nextjs-frontend/templates/src/app/layout.tsx.j2
@@ -1,0 +1,29 @@
+{% if styling == "tailwind" or styling == "scss" %}import "./globals.css";
+{% endif %}{% if language == "typescript" %}import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = {
+  title: "{{ display_name }}",
+  description: "{{ description }}",
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}
+{% else %}export const metadata = {
+  title: "{{ display_name }}",
+  description: "{{ description }}",
+};
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}
+{% endif %}

--- a/src/scaffoldkit/blueprints/nextjs-frontend/templates/src/app/page.test.tsx.j2
+++ b/src/scaffoldkit/blueprints/nextjs-frontend/templates/src/app/page.test.tsx.j2
@@ -1,0 +1,19 @@
+{% if test_strategy == "vitest-only" or test_strategy == "vitest-and-playwright" -%}
+import { describe, it, expect } from "vitest";
+{% endif -%}
+import { render, screen } from "@testing-library/react";
+import HomePage from "./page";
+
+describe("HomePage", () => {
+  it("renders the project name heading", () => {
+    render(<HomePage />);
+    expect(
+      screen.getByRole("heading", { name: "{{ display_name }}", level: 1 })
+    ).toBeInTheDocument();
+  });
+
+  it("renders the welcome card", () => {
+    render(<HomePage />);
+    expect(screen.getByText(/Welcome to {{ project_name }}/)).toBeInTheDocument();
+  });
+});

--- a/src/scaffoldkit/blueprints/nextjs-frontend/templates/src/app/page.tsx.j2
+++ b/src/scaffoldkit/blueprints/nextjs-frontend/templates/src/app/page.tsx.j2
@@ -1,0 +1,11 @@
+import { WelcomeCard } from "@/components/features/WelcomeCard";
+
+export default function HomePage() {
+  return (
+    <main{% if styling == "tailwind" %} className="flex min-h-screen flex-col items-center justify-center gap-6 p-6"{% endif %}>
+      <h1{% if styling == "tailwind" %} className="text-2xl font-semibold"{% endif %}>{{ display_name }}</h1>
+      <p{% if styling == "tailwind" %} className="text-muted-foreground"{% endif %}>{{ description }}</p>
+      <WelcomeCard projectName="{{ project_name }}" />
+    </main>
+  );
+}

--- a/src/scaffoldkit/blueprints/nextjs-frontend/templates/src/components/features/WelcomeCard.tsx.j2
+++ b/src/scaffoldkit/blueprints/nextjs-frontend/templates/src/components/features/WelcomeCard.tsx.j2
@@ -1,0 +1,16 @@
+{% if language == "typescript" %}interface WelcomeCardProps {
+  projectName: string;
+}
+
+export function WelcomeCard({ projectName }: WelcomeCardProps) {
+{% else %}export function WelcomeCard({ projectName }) {
+{% endif %}  return (
+    <section{% if styling == "tailwind" %} className="rounded-lg border bg-card p-6 shadow-sm"{% endif %}>
+      <h2{% if styling == "tailwind" %} className="text-xl font-medium"{% endif %}>Welcome to {projectName}</h2>
+      <p{% if styling == "tailwind" %} className="mt-2 text-sm text-muted-foreground"{% endif %}>
+        This starter renders a real authored route. Edit{" "}
+        <code>src/app/page.tsx</code> to begin building your application.
+      </p>
+    </section>
+  );
+}

--- a/src/scaffoldkit/blueprints/nextjs-frontend/templates/tailwind.config.ts.j2
+++ b/src/scaffoldkit/blueprints/nextjs-frontend/templates/tailwind.config.ts.j2
@@ -1,0 +1,26 @@
+{% if styling == "tailwind" -%}
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: [
+    "./src/app/**/*.{ts,tsx,js,jsx,mdx}",
+    "./src/components/**/*.{ts,tsx,js,jsx,mdx}",
+  ],
+  theme: {
+    extend: {
+      colors: {
+        background: "var(--background)",
+        foreground: "var(--foreground)",
+        card: "var(--card)",
+        "muted-foreground": "var(--muted-foreground)",
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;
+{%- else -%}
+// Tailwind is not the selected styling solution for this project.
+export {};
+{%- endif %}

--- a/src/scaffoldkit/blueprints/nextjs-frontend/templates/vitest.config.ts.j2
+++ b/src/scaffoldkit/blueprints/nextjs-frontend/templates/vitest.config.ts.j2
@@ -1,0 +1,17 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./vitest.setup.ts"],
+  },
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("./src", import.meta.url)),
+    },
+  },
+});

--- a/src/scaffoldkit/blueprints/nextjs-frontend/templates/vitest.setup.ts.j2
+++ b/src/scaffoldkit/blueprints/nextjs-frontend/templates/vitest.setup.ts.j2
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";

--- a/tests/test_nextjs_frontend_starter.py
+++ b/tests/test_nextjs_frontend_starter.py
@@ -1,0 +1,120 @@
+"""Tests for the nextjs-frontend runnable starter (Phase-3 Batch B1)."""
+
+import json
+from pathlib import Path
+
+from scaffoldkit.blueprint_loader import load_blueprint
+from scaffoldkit.generator import generate
+from scaffoldkit.models import GenerationContext
+
+BLUEPRINTS_DIR = Path(__file__).resolve().parent.parent / "src" / "scaffoldkit" / "blueprints"
+
+_DEFAULTS = {
+    "project_name": "my-frontend",
+    "display_name": "My Frontend",
+    "description": "A Next.js frontend application",
+    "nextjs_version": "15",
+    "router": "app-router",
+    "language": "typescript",
+    "styling": "tailwind",
+    "ui_library": "shadcn-ui",
+    "state_management": "zustand",
+    "api_client": "tanstack-query",
+    "use_auth": True,
+    "auth_provider": "next-auth",
+    "use_i18n": False,
+    "use_storybook": False,
+    "use_docker": True,
+    "use_ci": True,
+    "test_strategy": "vitest-only",
+    "design_style": "minimal-clean",
+    "ai_context": True,
+}
+
+
+def _generate(tmp_path: Path, variables: dict) -> Path:
+    bp_path = BLUEPRINTS_DIR / "nextjs-frontend"
+    bp = load_blueprint(bp_path)
+    output = tmp_path / "output"
+    ctx = GenerationContext(
+        blueprint=bp,
+        blueprint_path=bp_path,
+        variables=variables,
+        target_dir=output,
+    )
+    result = generate(ctx)
+    assert result.success, f"Generation failed: {result.errors}"
+    return output
+
+
+class TestNextjsFrontendStarter:
+    def test_emits_runnable_app_router_starter(self, tmp_path: Path):
+        output = _generate(tmp_path, _DEFAULTS)
+
+        # The starter must emit a real authored route, not just empty src/ dirs.
+        # Regression: the blueprint previously left src/app empty, so `next build`
+        # only produced the framework /404 and /500 pages.
+        layout = output / "src" / "app" / "layout.tsx"
+        page = output / "src" / "app" / "page.tsx"
+        component = output / "src" / "components" / "features" / "WelcomeCard.tsx"
+
+        for f in (layout, page, component):
+            assert f.exists(), f"expected starter file missing: {f}"
+            assert f.read_text().strip(), f"starter file is empty: {f}"
+
+        # The home page is the authored "/" route and renders the example component.
+        page_text = page.read_text()
+        assert "export default function HomePage" in page_text
+        assert "WelcomeCard" in page_text
+
+        # The root layout imports the global stylesheet and sets metadata.
+        layout_text = layout.read_text()
+        assert 'import "./globals.css";' in layout_text
+        assert "export default function RootLayout" in layout_text
+
+    def test_emits_tailwind_wiring(self, tmp_path: Path):
+        output = _generate(tmp_path, _DEFAULTS)
+
+        globals_css = output / "src" / "app" / "globals.css"
+        tailwind_config = output / "tailwind.config.ts"
+        postcss_config = output / "postcss.config.mjs"
+
+        assert globals_css.exists() and globals_css.read_text().strip()
+        assert "@tailwind base;" in globals_css.read_text()
+        assert tailwind_config.exists() and tailwind_config.read_text().strip()
+        assert postcss_config.exists()
+        assert "tailwindcss: {}" in postcss_config.read_text()
+
+    def test_emits_smoke_test_and_runner_config(self, tmp_path: Path):
+        output = _generate(tmp_path, _DEFAULTS)
+
+        smoke_test = output / "src" / "app" / "page.test.tsx"
+        vitest_config = output / "vitest.config.ts"
+        vitest_setup = output / "vitest.setup.ts"
+
+        for f in (smoke_test, vitest_config, vitest_setup):
+            assert f.exists(), f"expected test scaffold missing: {f}"
+            assert f.read_text().strip(), f"test scaffold file is empty: {f}"
+
+        # The smoke test asserts the authored home page renders.
+        test_text = smoke_test.read_text()
+        assert "@testing-library/react" in test_text
+        assert "HomePage" in test_text
+
+    def test_next_is_pinned_off_the_vulnerable_release(self, tmp_path: Path):
+        output = _generate(tmp_path, _DEFAULTS)
+        pkg = json.loads((output / "package.json").read_text())
+
+        # CVE-2025-66478: next 15.2.4 was vulnerable; bump to a patched 15.x.
+        assert pkg["dependencies"]["next"] == "15.5.19"
+        assert pkg["devDependencies"]["eslint-config-next"] == "15.5.19"
+
+        # The pnpm packageManager pin was dropped so npm/yarn installs work too.
+        assert "packageManager" not in pkg
+
+        # The testing-library + jsdom toolchain ships so the smoke test runs.
+        dev = pkg["devDependencies"]
+        assert "@testing-library/react" in dev
+        assert "jsdom" in dev
+        assert "@vitejs/plugin-react" in dev
+        assert "tailwindcss" in dev


### PR DESCRIPTION
## What
The `nextjs-frontend` blueprint emitted empty `src/` (next build false-green, only `/404`).

## Fix
Emit an app-router starter: `src/app/layout.tsx`, `src/app/page.tsx`, an example component, `globals.css` + Tailwind wiring, and a vitest smoke test. Bumps next off 15.2.4 (CVE-2025-66478) to 15.5.19. Adds a per-blueprint regression test.

## Verification
`next build` emits an authored `/` route (not just `/404`), vitest passes (jsdom render), scaffoldkit pytest + `uv build` green. Rigorous review subagent: SHIP, 0 must-fix.

Known follow-up (scope-out): non-default `test_strategy=jest` + JS-path config gating.

Refs: PHASE3_LANE_A_REPORT_2026-06-02.md