### PR TITLE
feat(static-site): emit runnable Astro starter + smoke test

### DIFF
--- a/src/scaffoldkit/blueprints/static-site/blueprint.yaml
+++ b/src/scaffoldkit/blueprints/static-site/blueprint.yaml
@@ -115,6 +115,55 @@ templates:
   - source: package.json.j2
     target: package.json
 
+  # --- Astro runnable starter (gated on framework == astro) ---
+  - source: astro.config.mjs.j2
+    target: astro.config.mjs
+    condition: is_astro
+
+  - source: tsconfig.json.j2
+    target: tsconfig.json
+    condition: is_astro
+
+  - source: src/layouts/Base.astro.j2
+    target: src/layouts/Base.astro
+    condition: is_astro
+
+  - source: src/pages/index.astro.j2
+    target: src/pages/index.astro
+    condition: is_astro
+
+  - source: src/styles/global.css.j2
+    target: src/styles/global.css
+    condition: is_astro
+
+  - source: src/content.config.ts.j2
+    target: src/content.config.ts
+    condition: is_astro
+
+  - source: src/content/docs/index.md.j2
+    target: src/content/docs/index.md
+    condition: is_astro_docs
+
+  - source: src/content/blog/welcome.md.j2
+    target: src/content/blog/welcome.md
+    condition: is_astro_blog
+
+  - source: src/content/projects/example-project.md.j2
+    target: src/content/projects/example-project.md
+    condition: is_astro_portfolio
+
+  - source: src/content/sections/hero.md.j2
+    target: src/content/sections/hero.md
+    condition: is_astro_landing_page
+
+  - source: tailwind.config.mjs.j2
+    target: tailwind.config.mjs
+    condition: is_astro_tailwind
+
+  - source: tests/site.test.mjs.j2
+    target: tests/site.test.mjs
+    condition: is_astro
+
   - source: .github/workflows/deploy.yml.j2
     target: .github/workflows/deploy.yml
     condition: use_ci

--- a/src/scaffoldkit/blueprints/static-site/templates/astro.config.mjs.j2
+++ b/src/scaffoldkit/blueprints/static-site/templates/astro.config.mjs.j2
@@ -1,0 +1,19 @@
+// @ts-check
+import { defineConfig } from "astro/config";
+{% if styling == "tailwind" %}
+import tailwind from "@astrojs/tailwind";
+{% endif %}
+
+// Astro configuration for {{ display_name }}.
+// Docs: https://docs.astro.build/en/reference/configuration-reference/
+export default defineConfig({
+{% if use_i18n %}
+  i18n: {
+    defaultLocale: "en",
+    locales: ["en"],
+  },
+{% endif %}
+{% if styling == "tailwind" %}
+  integrations: [tailwind()],
+{% endif %}
+});

--- a/src/scaffoldkit/blueprints/static-site/templates/package.json.j2
+++ b/src/scaffoldkit/blueprints/static-site/templates/package.json.j2
@@ -4,18 +4,19 @@
   "private": true,
   "description": "{{ description }}",
   "scripts": {
-{% if framework == "astro" -%}
+{% if framework == "astro" %}
     "dev": "astro dev",
     "build": "astro build",
-    "preview": "astro preview"
-{% elif framework == "nextjs-static" -%}
+    "preview": "astro preview",
+    "test": "node --test"
+{% elif framework == "nextjs-static" %}
     "dev": "next dev",
     "build": "next build",
     "preview": "next start"
-{% elif framework == "eleventy" -%}
+{% elif framework == "eleventy" %}
     "dev": "npx @11ty/eleventy --serve",
     "build": "npx @11ty/eleventy"
-{% else -%}
+{% else %}
     "dev": "hugo server --buildDrafts",
     "build": "hugo",
     "preview": "hugo server"
@@ -25,15 +26,25 @@
     "node": ">=20"
   }{% if framework != "hugo" %},
   "dependencies": {
-{% if framework == "astro" -%}
+{% if framework == "astro" %}
+{% if styling == "tailwind" %}
+    "astro": "^5.5.2",
+    "@astrojs/tailwind": "^5.1.5",
+    "tailwindcss": "^3.4.17"
+{% else %}
     "astro": "^5.5.2"
-{% elif framework == "nextjs-static" -%}
+{% endif %}
+{% elif framework == "nextjs-static" %}
     "next": "^15.2.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
-{% else -%}
+{% else %}
     "@11ty/eleventy": "^3.0.0"
 {% endif %}
+  }{% if framework == "astro" %},
+  "devDependencies": {
+    "@types/node": "^22.13.14"
   }
+{% endif %}
 {% endif %}
 }

--- a/src/scaffoldkit/blueprints/static-site/templates/src/content.config.ts.j2
+++ b/src/scaffoldkit/blueprints/static-site/templates/src/content.config.ts.j2
@@ -1,0 +1,57 @@
+// Content collection schemas. Frontmatter is validated against these at build.
+// Docs: https://docs.astro.build/en/guides/content-collections/
+import { defineCollection, z } from "astro:content";
+import { glob } from "astro/loaders";
+
+{% if site_type == "blog" -%}
+const blog = defineCollection({
+  loader: glob({ pattern: "**/*.{md,mdx}", base: "./src/content/blog" }),
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    pubDate: z.coerce.date(),
+    author: z.string().optional(),
+    tags: z.array(z.string()).default([]),
+    draft: z.boolean().default(false),
+  }),
+});
+
+export const collections = { blog };
+{%- elif site_type == "portfolio" -%}
+const projects = defineCollection({
+  loader: glob({ pattern: "**/*.{md,mdx}", base: "./src/content/projects" }),
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    date: z.coerce.date(),
+    tags: z.array(z.string()).default([]),
+    status: z.enum(["completed", "in-progress", "archived"]).default("completed"),
+    featured: z.boolean().default(false),
+  }),
+});
+
+export const collections = { projects };
+{%- elif site_type == "landing-page" -%}
+const sections = defineCollection({
+  loader: glob({ pattern: "**/*.{md,mdx}", base: "./src/content/sections" }),
+  schema: z.object({
+    title: z.string(),
+    sectionId: z.string().optional(),
+    order: z.number().default(99),
+    visible: z.boolean().default(true),
+  }),
+});
+
+export const collections = { sections };
+{%- else -%}
+const docs = defineCollection({
+  loader: glob({ pattern: "**/*.{md,mdx}", base: "./src/content/docs" }),
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    draft: z.boolean().default(false),
+  }),
+});
+
+export const collections = { docs };
+{%- endif %}

--- a/src/scaffoldkit/blueprints/static-site/templates/src/content/blog/welcome.md.j2
+++ b/src/scaffoldkit/blueprints/static-site/templates/src/content/blog/welcome.md.j2
@@ -1,0 +1,16 @@
+---
+title: "Welcome to {{ display_name }}"
+description: "The first post on {{ display_name }}."
+pubDate: "2024-01-01"
+tags:
+  - announcement
+draft: false
+---
+
+# Welcome
+
+This is the first post on {{ display_name }}.
+
+It lives at `src/content/blog/welcome.md` and is validated against the
+`blog` collection schema in `src/content.config.ts`. Add more `.md` files
+under `src/content/blog/` for each new post.

--- a/src/scaffoldkit/blueprints/static-site/templates/src/content/docs/index.md.j2
+++ b/src/scaffoldkit/blueprints/static-site/templates/src/content/docs/index.md.j2
@@ -1,0 +1,22 @@
+---
+title: "Getting Started"
+description: "Introduction to {{ display_name }} and how the documentation is organised."
+draft: false
+---
+
+# Getting Started
+
+Welcome to the {{ display_name }} documentation.
+
+This page lives at `src/content/docs/index.md`. Add more `.md` or `.mdx`
+files under `src/content/docs/` and they become entries in the `docs`
+content collection (see `src/content.config.ts` for the schema).
+
+## Next steps
+
+- Edit this file to replace the placeholder content.
+- Add a new doc page, for example `src/content/docs/installation.md`.
+- Link to it from the home page navigation in `src/pages/index.astro`.
+
+See [docs/content-guide.md](../../../docs/content-guide.md) for the full
+frontmatter reference and content conventions.

--- a/src/scaffoldkit/blueprints/static-site/templates/src/content/projects/example-project.md.j2
+++ b/src/scaffoldkit/blueprints/static-site/templates/src/content/projects/example-project.md.j2
@@ -1,0 +1,17 @@
+---
+title: "Example Project"
+description: "A placeholder portfolio entry for {{ display_name }}."
+date: "2024-01-01"
+tags:
+  - example
+status: "completed"
+featured: true
+---
+
+# Example Project
+
+A placeholder project entry on {{ display_name }}.
+
+It lives at `src/content/projects/example-project.md` and is validated
+against the `projects` collection schema in `src/content.config.ts`.
+Duplicate this file for each new portfolio entry.

--- a/src/scaffoldkit/blueprints/static-site/templates/src/content/sections/hero.md.j2
+++ b/src/scaffoldkit/blueprints/static-site/templates/src/content/sections/hero.md.j2
@@ -1,0 +1,12 @@
+---
+title: "Welcome to {{ display_name }}"
+sectionId: "hero"
+order: 1
+visible: true
+---
+
+{{ description }}
+
+This section lives at `src/content/sections/hero.md` and is validated
+against the `sections` collection schema in `src/content.config.ts`.
+Add more sections (features, pricing, faq) as additional `.md` files.

--- a/src/scaffoldkit/blueprints/static-site/templates/src/layouts/Base.astro.j2
+++ b/src/scaffoldkit/blueprints/static-site/templates/src/layouts/Base.astro.j2
@@ -1,0 +1,36 @@
+---
+// Base layout: the HTML shell shared by every page.
+// Wraps page content with <head> metadata and global styles.
+import "@/styles/global.css";
+
+interface Props {
+  title: string;
+  description?: string;
+}
+
+const siteName = "{{ display_name }}";
+const { title, description = "{{ description }}" } = Astro.props;
+const pageTitle = title === siteName ? title : `${title} - ${siteName}`;
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="generator" content={Astro.generator} />
+    <meta name="description" content={description} />
+    <title>{pageTitle}</title>
+  </head>
+  <body>
+    <header>
+      <a href="/">{siteName}</a>
+    </header>
+    <main>
+      <slot />
+    </main>
+    <footer>
+      <p>&copy; {new Date().getFullYear()} {siteName}</p>
+    </footer>
+  </body>
+</html>

--- a/src/scaffoldkit/blueprints/static-site/templates/src/pages/index.astro.j2
+++ b/src/scaffoldkit/blueprints/static-site/templates/src/pages/index.astro.j2
@@ -1,0 +1,38 @@
+---
+// Home page. Route "/" -> dist/index.html.
+import Base from "@/layouts/Base.astro";
+{% if site_type == "docs" %}
+import { getCollection } from "astro:content";
+
+const docs = await getCollection("docs");
+{% endif %}
+---
+
+<Base title="{{ display_name }}">
+  <h1>{{ display_name }}</h1>
+  <p>{{ description }}</p>
+{% if site_type == "docs" %}
+  <nav aria-label="Documentation">
+    <h2>Documentation</h2>
+    <ul>
+      {docs.map((entry) => (
+        <li>
+          <a href={`/docs/${entry.id.replace(/\.(md|mdx)$/, "")}`}>
+            {entry.data.title}
+          </a>
+        </li>
+      ))}
+    </ul>
+  </nav>
+{% elif site_type == "blog" %}
+  <p>Welcome to the blog. Posts live in <code>src/content/blog/</code>.</p>
+{% elif site_type == "portfolio" %}
+  <p>Project entries live in <code>src/content/projects/</code>.</p>
+{% else %}
+  <p>Edit this page in <code>src/pages/index.astro</code>.</p>
+{% endif %}
+  <p>
+    Edit <code>src/pages/index.astro</code> to change this page, or add
+    new files under <code>src/pages/</code> to create routes.
+  </p>
+</Base>

--- a/src/scaffoldkit/blueprints/static-site/templates/src/styles/global.css.j2
+++ b/src/scaffoldkit/blueprints/static-site/templates/src/styles/global.css.j2
@@ -1,0 +1,56 @@
+{% if styling == "tailwind" -%}
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/*
+ * Extract repeated utility patterns into component classes with @apply
+ * when a pattern appears three or more times. See docs/architecture.md.
+ */
+{%- elif styling == "scss" -%}
+/* Global styles for {{ display_name }}. Compiled from SCSS at build time. */
+:root {
+  --color-text: #1a1a1a;
+  --color-bg: #ffffff;
+  --color-accent: #2563eb;
+  --font-sans: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --space: 1rem;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-sans);
+  color: var(--color-text);
+  background: var(--color-bg);
+  line-height: 1.6;
+}
+{%- else -%}
+/* Global styles for {{ display_name }}. Plain CSS with custom properties for tokens. */
+:root {
+  --color-text: #1a1a1a;
+  --color-bg: #ffffff;
+  --color-accent: #2563eb;
+  --font-sans: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --space: 1rem;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-sans);
+  color: var(--color-text);
+  background: var(--color-bg);
+  line-height: 1.6;
+}
+{%- endif %}

--- a/src/scaffoldkit/blueprints/static-site/templates/tailwind.config.mjs.j2
+++ b/src/scaffoldkit/blueprints/static-site/templates/tailwind.config.mjs.j2
@@ -1,0 +1,9 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ["./src/**/*.{astro,html,js,jsx,ts,tsx,md,mdx}"],
+  theme: {
+    // Design tokens (colours, spacing, typography) go under theme.extend.
+    extend: {},
+  },
+  plugins: [],
+};

--- a/src/scaffoldkit/blueprints/static-site/templates/tests/site.test.mjs.j2
+++ b/src/scaffoldkit/blueprints/static-site/templates/tests/site.test.mjs.j2
@@ -1,0 +1,32 @@
+// Smoke test for {{ display_name }}.
+// Verifies the Astro build emits a real home page (dist/index.html), not
+// an empty "0 page(s) built" result. Builds on demand so `npm test` is
+// self-contained. Run with: npm test (node --test).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const indexHtml = join(root, "dist", "index.html");
+
+function ensureBuilt() {
+  if (existsSync(indexHtml)) return;
+  execFileSync("npx", ["astro", "build"], { cwd: root, stdio: "inherit" });
+}
+
+test("astro build emits a home page", () => {
+  ensureBuilt();
+  assert.ok(existsSync(indexHtml), "dist/index.html should exist after build");
+});
+
+test("home page contains the site name", () => {
+  ensureBuilt();
+  const html = readFileSync(indexHtml, "utf8");
+  assert.ok(
+    html.includes({{ display_name | tojson }}),
+    "home page should render the site name",
+  );
+});

--- a/src/scaffoldkit/blueprints/static-site/templates/tsconfig.json.j2
+++ b/src/scaffoldkit/blueprints/static-site/templates/tsconfig.json.j2
@@ -1,0 +1,11 @@
+{
+  "extends": "astro/tsconfigs/strict",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": [".astro/types.d.ts", "**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/src/scaffoldkit/generator.py
+++ b/src/scaffoldkit/generator.py
@@ -80,6 +80,14 @@ def build_template_context(blueprint: Blueprint, variables: dict[str, Any]) -> d
     ctx["is_symfony_api_react_ci"] = ctx["is_symfony_api_react"] and use_ci
     ctx["is_django_htmx_ci"] = ctx["is_django_htmx"] and use_ci
     ctx["is_rails_hotwire_ci"] = ctx["is_rails_hotwire"] and use_ci
+    # static-site (Astro) starter discriminators: framework + styling/site_type
+    styling = str(variables.get("styling", "")).lower()
+    site_type = str(variables.get("site_type", "")).lower()
+    ctx["is_astro_tailwind"] = ctx["is_astro"] and styling == "tailwind"
+    ctx["is_astro_docs"] = ctx["is_astro"] and site_type == "docs"
+    ctx["is_astro_blog"] = ctx["is_astro"] and site_type == "blog"
+    ctx["is_astro_portfolio"] = ctx["is_astro"] and site_type == "portfolio"
+    ctx["is_astro_landing_page"] = ctx["is_astro"] and site_type == "landing-page"
     ctx.update(blueprint.metadata)
     return ctx
 

--- a/tests/test_static_site_starter.py
+++ b/tests/test_static_site_starter.py
@@ -1,0 +1,126 @@
+"""Tests for the static-site blueprint runnable starter (Astro path)."""
+
+import json
+from pathlib import Path
+
+from scaffoldkit.blueprint_loader import load_blueprint
+from scaffoldkit.generator import generate
+from scaffoldkit.models import GenerationContext
+
+BLUEPRINTS_DIR = Path(__file__).resolve().parent.parent / "src" / "scaffoldkit" / "blueprints"
+
+_DEFAULTS = {
+    "project_name": "my-site",
+    "display_name": "My Site",
+    "description": "A static website",
+    "site_type": "docs",
+    "framework": "astro",
+    "styling": "tailwind",
+    "use_cms": False,
+    "cms_type": "markdown-files",
+    "use_i18n": False,
+    "use_analytics": False,
+    "use_ci": True,
+    "deploy_target": "vercel",
+    "ai_context": True,
+}
+
+
+def _generate(tmp_path: Path, variables: dict) -> Path:
+    bp_path = BLUEPRINTS_DIR / "static-site"
+    bp = load_blueprint(bp_path)
+    output = tmp_path / "output"
+    ctx = GenerationContext(
+        blueprint=bp,
+        blueprint_path=bp_path,
+        variables=variables,
+        target_dir=output,
+    )
+    result = generate(ctx)
+    assert result.success, f"Generation failed: {result.errors}"
+    return output
+
+
+class TestStaticSiteStarter:
+    def test_emits_runnable_astro_starter(self, tmp_path: Path):
+        output = _generate(tmp_path, _DEFAULTS)
+
+        # Framework config + a real entry point, layout, and page.
+        starter_files = [
+            "astro.config.mjs",
+            "tsconfig.json",
+            "src/layouts/Base.astro",
+            "src/pages/index.astro",
+            "src/styles/global.css",
+            "src/content.config.ts",
+            "src/content/docs/index.md",
+            "tests/site.test.mjs",
+        ]
+        for rel in starter_files:
+            path = output / rel
+            assert path.exists(), f"missing starter file: {rel}"
+            assert path.read_text().strip(), f"empty starter file: {rel}"
+
+        # The page uses the base layout, and the layout wraps content.
+        index = (output / "src" / "pages" / "index.astro").read_text()
+        assert 'import Base from "@/layouts/Base.astro"' in index
+        layout = (output / "src" / "layouts" / "Base.astro").read_text()
+        assert "<slot />" in layout
+        assert 'import "@/styles/global.css"' in layout
+
+    def test_tailwind_dependency_and_integration_are_wired(self, tmp_path: Path):
+        # Regression: the blueprint declared styling=tailwind by default but
+        # shipped no tailwind dependency or integration, so the build had no
+        # working styling pipeline. Both must now be present.
+        output = _generate(tmp_path, _DEFAULTS)
+
+        pkg = json.loads((output / "package.json").read_text())
+        assert "@astrojs/tailwind" in pkg["dependencies"]
+        assert "tailwindcss" in pkg["dependencies"]
+        assert pkg["scripts"]["test"] == "node --test"
+
+        config = (output / "astro.config.mjs").read_text()
+        assert 'import tailwind from "@astrojs/tailwind"' in config
+        assert "integrations: [tailwind()]" in config
+        assert (output / "tailwind.config.mjs").exists()
+        assert "@tailwind base;" in (output / "src" / "styles" / "global.css").read_text()
+
+    def test_non_tailwind_astro_skips_tailwind_wiring(self, tmp_path: Path):
+        output = _generate(tmp_path, {**_DEFAULTS, "styling": "vanilla-css"})
+
+        pkg = json.loads((output / "package.json").read_text())
+        assert "@astrojs/tailwind" not in pkg["dependencies"]
+        assert "tailwindcss" not in pkg["dependencies"]
+        assert not (output / "tailwind.config.mjs").exists()
+
+        config = (output / "astro.config.mjs").read_text()
+        assert "tailwind" not in config
+        assert "@tailwind base;" not in (output / "src" / "styles" / "global.css").read_text()
+
+    def test_content_collection_matches_site_type(self, tmp_path: Path):
+        blog = _generate(tmp_path / "blog", {**_DEFAULTS, "site_type": "blog"})
+        assert (blog / "src" / "content" / "blog" / "welcome.md").exists()
+        assert not (blog / "src" / "content" / "docs" / "index.md").exists()
+        assert "const blog = defineCollection" in (blog / "src" / "content.config.ts").read_text()
+
+        portfolio = _generate(tmp_path / "portfolio", {**_DEFAULTS, "site_type": "portfolio"})
+        assert (portfolio / "src" / "content" / "projects" / "example-project.md").exists()
+        assert (
+            "const projects = defineCollection"
+            in (portfolio / "src" / "content.config.ts").read_text()
+        )
+
+        landing = _generate(tmp_path / "landing", {**_DEFAULTS, "site_type": "landing-page"})
+        assert (landing / "src" / "content" / "sections" / "hero.md").exists()
+        assert (
+            "const sections = defineCollection"
+            in (landing / "src" / "content.config.ts").read_text()
+        )
+
+    def test_non_astro_framework_skips_astro_starter(self, tmp_path: Path):
+        output = _generate(tmp_path, {**_DEFAULTS, "framework": "eleventy"})
+
+        assert not (output / "astro.config.mjs").exists()
+        assert not (output / "src" / "pages" / "index.astro").exists()
+        assert not (output / "src" / "content.config.ts").exists()
+        assert not (output / "tests" / "site.test.mjs").exists()


### PR DESCRIPTION
## What
The `static-site` blueprint emitted empty `src/` (build reported "0 pages", Tailwind dependency missing).

## Fix
Emit an Astro starter: `astro.config.mjs`, `tsconfig.json`, `src/layouts/Base.astro`, `src/pages/index.astro`, a content collection, and Tailwind wiring, plus a smoke test. Adds a per-blueprint regression test.

## Verification
`npm install` + `npx astro build` builds at least one page (`dist/index.html` exists), scaffoldkit pytest + `uv build` green. Rigorous review subagent: SHIP, 0 must-fix.

Refs: PHASE3_LANE_A_REPORT_2026-06-02.md