### PR TITLE
feat(django-drf): emit runnable Django REST starter + smoke test

### DIFF
--- a/src/scaffoldkit/blueprints/django-drf/blueprint.yaml
+++ b/src/scaffoldkit/blueprints/django-drf/blueprint.yaml
@@ -117,6 +117,70 @@ templates:
   - source: requirements-dev.txt.j2
     target: requirements-dev.txt
 
+  # Minimal runnable Django + DRF starter so the blueprint emits real source, not
+  # just empty config/ and apps/ directories. All entries are unconditional: this
+  # blueprint is always Django/DRF. The layout matches the declared directories
+  # (config/ as a project package, config/settings/ as a settings package resolving
+  # to DJANGO_SETTINGS_MODULE=config.settings, apps/api + apps/users as DRF apps).
+  # Local/test DB is SQLite so `python manage.py check` and the pytest-django smoke
+  # test run with no live server.
+  - source: manage.py.j2
+    target: manage.py
+
+  - source: config/__init__.py.j2
+    target: config/__init__.py
+
+  - source: config/settings/__init__.py.j2
+    target: config/settings/__init__.py
+
+  - source: config/urls.py.j2
+    target: config/urls.py
+
+  - source: config/wsgi.py.j2
+    target: config/wsgi.py
+
+  - source: config/asgi.py.j2
+    target: config/asgi.py
+
+  - source: apps/__init__.py.j2
+    target: apps/__init__.py
+
+  - source: apps/common/__init__.py.j2
+    target: apps/common/__init__.py
+
+  - source: apps/api/__init__.py.j2
+    target: apps/api/__init__.py
+
+  - source: apps/api/apps.py.j2
+    target: apps/api/apps.py
+
+  - source: apps/api/serializers.py.j2
+    target: apps/api/serializers.py
+
+  - source: apps/api/views.py.j2
+    target: apps/api/views.py
+
+  - source: apps/api/urls.py.j2
+    target: apps/api/urls.py
+
+  - source: apps/api/migrations/__init__.py.j2
+    target: apps/api/migrations/__init__.py
+
+  - source: apps/users/__init__.py.j2
+    target: apps/users/__init__.py
+
+  - source: apps/users/apps.py.j2
+    target: apps/users/apps.py
+
+  - source: apps/users/migrations/__init__.py.j2
+    target: apps/users/migrations/__init__.py
+
+  - source: tests/__init__.py.j2
+    target: tests/__init__.py
+
+  - source: tests/test_health.py.j2
+    target: tests/test_health.py
+
   - source: .dockerignore.j2
     target: .dockerignore
     condition: use_docker

--- a/src/scaffoldkit/blueprints/django-drf/templates/README.md.j2
+++ b/src/scaffoldkit/blueprints/django-drf/templates/README.md.j2
@@ -62,12 +62,18 @@ Expected API docs:
 
 ```text
 {{ project_name }}/
+├── manage.py            # Django command-line entry point
 ├── config/              # Django project config and settings split
+│   ├── settings/        # settings package (DJANGO_SETTINGS_MODULE=config.settings)
+│   ├── urls.py          # root URLconf, wires apps.api under /api/
+│   ├── wsgi.py
+│   └── asgi.py
 ├── apps/
-│   ├── api/             # DRF resources and API composition
+│   ├── api/             # DRF health endpoint, serializer, app URLs
 │   ├── users/           # authentication and identity domain
 │   └── common/          # shared domain utilities
 ├── tests/
+│   ├── test_health.py   # pytest-django smoke test for GET /api/health
 │   └── integration/     # API and persistence integration tests
 ├── docs/
 │   ├── architecture.md

--- a/src/scaffoldkit/blueprints/django-drf/templates/apps/__init__.py.j2
+++ b/src/scaffoldkit/blueprints/django-drf/templates/apps/__init__.py.j2
@@ -1,0 +1,1 @@
+"""Domain application packages for {{ display_name }}."""

--- a/src/scaffoldkit/blueprints/django-drf/templates/apps/api/__init__.py.j2
+++ b/src/scaffoldkit/blueprints/django-drf/templates/apps/api/__init__.py.j2
@@ -1,0 +1,1 @@
+"""DRF API application: resources, serializers, and URL composition."""

--- a/src/scaffoldkit/blueprints/django-drf/templates/apps/api/apps.py.j2
+++ b/src/scaffoldkit/blueprints/django-drf/templates/apps/api/apps.py.j2
@@ -1,0 +1,9 @@
+"""App configuration for the DRF API application."""
+from django.apps import AppConfig
+
+
+class ApiConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    # Nested under apps/, so the import path is the dotted label Django expects.
+    name = "apps.api"
+    label = "api"

--- a/src/scaffoldkit/blueprints/django-drf/templates/apps/api/serializers.py.j2
+++ b/src/scaffoldkit/blueprints/django-drf/templates/apps/api/serializers.py.j2
@@ -1,0 +1,9 @@
+"""Serializers for the DRF API application."""
+from rest_framework import serializers
+
+
+class HealthSerializer(serializers.Serializer):
+    """Shape of the health probe response."""
+
+    status = serializers.CharField()
+    service = serializers.CharField()

--- a/src/scaffoldkit/blueprints/django-drf/templates/apps/api/urls.py.j2
+++ b/src/scaffoldkit/blueprints/django-drf/templates/apps/api/urls.py.j2
@@ -1,0 +1,10 @@
+"""URL routes for the DRF API application."""
+from django.urls import path
+
+from apps.api.views import HealthView
+
+app_name = "api"
+
+urlpatterns = [
+    path("health", HealthView.as_view(), name="health"),
+]

--- a/src/scaffoldkit/blueprints/django-drf/templates/apps/api/views.py.j2
+++ b/src/scaffoldkit/blueprints/django-drf/templates/apps/api/views.py.j2
@@ -1,0 +1,17 @@
+"""Views for the DRF API application."""
+from rest_framework.permissions import AllowAny
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.api.serializers import HealthSerializer
+
+
+class HealthView(APIView):
+    """Liveness probe used by orchestration and smoke tests."""
+
+    permission_classes = [AllowAny]
+
+    def get(self, request: Request) -> Response:
+        payload = {"status": "ok", "service": "{{ project_name }}"}
+        return Response(HealthSerializer(payload).data)

--- a/src/scaffoldkit/blueprints/django-drf/templates/apps/common/__init__.py.j2
+++ b/src/scaffoldkit/blueprints/django-drf/templates/apps/common/__init__.py.j2
@@ -1,0 +1,1 @@
+"""Shared domain utilities for {{ display_name }}."""

--- a/src/scaffoldkit/blueprints/django-drf/templates/apps/users/__init__.py.j2
+++ b/src/scaffoldkit/blueprints/django-drf/templates/apps/users/__init__.py.j2
@@ -1,0 +1,1 @@
+"""Users application: authentication and identity domain."""

--- a/src/scaffoldkit/blueprints/django-drf/templates/apps/users/apps.py.j2
+++ b/src/scaffoldkit/blueprints/django-drf/templates/apps/users/apps.py.j2
@@ -1,0 +1,8 @@
+"""App configuration for the users application."""
+from django.apps import AppConfig
+
+
+class UsersConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.users"
+    label = "users"

--- a/src/scaffoldkit/blueprints/django-drf/templates/config/__init__.py.j2
+++ b/src/scaffoldkit/blueprints/django-drf/templates/config/__init__.py.j2
@@ -1,0 +1,1 @@
+"""{{ display_name }} Django project configuration package."""

--- a/src/scaffoldkit/blueprints/django-drf/templates/config/asgi.py.j2
+++ b/src/scaffoldkit/blueprints/django-drf/templates/config/asgi.py.j2
@@ -1,0 +1,8 @@
+"""ASGI entry point for {{ display_name }}."""
+import os
+
+from django.core.asgi import get_asgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+
+application = get_asgi_application()

--- a/src/scaffoldkit/blueprints/django-drf/templates/config/settings/__init__.py.j2
+++ b/src/scaffoldkit/blueprints/django-drf/templates/config/settings/__init__.py.j2
@@ -1,0 +1,101 @@
+"""Django settings for {{ display_name }}.
+
+The settings split lives in this package so `DJANGO_SETTINGS_MODULE=config.settings`
+resolves here. Local development and the test suite use SQLite so the starter runs
+with no live database; wire the configured engine ({{ database }}) for staging and
+production via environment variables.
+"""
+import os
+from pathlib import Path
+
+# config/settings/__init__.py -> config/settings -> config -> project root
+BASE_DIR = Path(__file__).resolve().parent.parent.parent
+
+SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY", "dev-insecure-change-me")
+
+DEBUG = os.environ.get("DJANGO_DEBUG", "1") == "1"
+
+ALLOWED_HOSTS = os.environ.get("DJANGO_ALLOWED_HOSTS", "localhost,127.0.0.1").split(",")
+
+INSTALLED_APPS = [
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "rest_framework",
+{% if use_drf_spectacular -%}
+    "drf_spectacular",
+{% endif -%}
+    "apps.api",
+    "apps.users",
+]
+
+MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+]
+
+ROOT_URLCONF = "config.urls"
+
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+            ],
+        },
+    },
+]
+
+WSGI_APPLICATION = "config.wsgi.application"
+ASGI_APPLICATION = "config.asgi.application"
+
+# SQLite keeps the generated starter runnable out of the box. Swap to the
+# configured engine ({{ database }}) by reading DATABASE_* from the environment.
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": BASE_DIR / "db.sqlite3",
+    }
+}
+
+AUTH_PASSWORD_VALIDATORS = [
+    {"NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"},
+    {"NAME": "django.contrib.auth.password_validation.MinimumLengthValidator"},
+    {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator"},
+    {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"},
+]
+
+LANGUAGE_CODE = "en-us"
+TIME_ZONE = "UTC"
+USE_I18N = True
+USE_TZ = True
+
+STATIC_URL = "static/"
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+REST_FRAMEWORK = {
+    "DEFAULT_PERMISSION_CLASSES": ["rest_framework.permissions.AllowAny"],
+{% if use_drf_spectacular -%}
+    "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+{% endif -%}
+}
+{% if use_drf_spectacular %}
+SPECTACULAR_SETTINGS = {
+    "TITLE": "{{ display_name }}",
+    "DESCRIPTION": "{{ description }}",
+    "VERSION": "0.1.0",
+}
+{% endif %}

--- a/src/scaffoldkit/blueprints/django-drf/templates/config/urls.py.j2
+++ b/src/scaffoldkit/blueprints/django-drf/templates/config/urls.py.j2
@@ -1,0 +1,18 @@
+"""Root URL configuration for {{ display_name }}."""
+from django.contrib import admin
+from django.urls import include, path
+{% if use_drf_spectacular -%}
+from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
+{% endif %}
+urlpatterns = [
+    path("admin/", admin.site.urls),
+    path("api/", include("apps.api.urls")),
+{% if use_drf_spectacular -%}
+    path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
+    path(
+        "api/schema/swagger-ui/",
+        SpectacularSwaggerView.as_view(url_name="schema"),
+        name="swagger-ui",
+    ),
+{% endif -%}
+]

--- a/src/scaffoldkit/blueprints/django-drf/templates/config/wsgi.py.j2
+++ b/src/scaffoldkit/blueprints/django-drf/templates/config/wsgi.py.j2
@@ -1,0 +1,8 @@
+"""WSGI entry point for {{ display_name }}."""
+import os
+
+from django.core.wsgi import get_wsgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+
+application = get_wsgi_application()

--- a/src/scaffoldkit/blueprints/django-drf/templates/manage.py.j2
+++ b/src/scaffoldkit/blueprints/django-drf/templates/manage.py.j2
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+"""{{ display_name }} - Django administrative command-line utility."""
+import os
+import sys
+
+
+def main() -> None:
+    """Run administrative tasks."""
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+    try:
+        from django.core.management import execute_from_command_line
+    except ImportError as exc:  # pragma: no cover - import guard
+        raise ImportError(
+            "Couldn't import Django. Are you sure it's installed and "
+            "available on your PYTHONPATH environment variable? Did you "
+            "forget to activate a virtual environment?"
+        ) from exc
+    execute_from_command_line(sys.argv)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scaffoldkit/blueprints/django-drf/templates/pyproject.toml.j2
+++ b/src/scaffoldkit/blueprints/django-drf/templates/pyproject.toml.j2
@@ -87,7 +87,9 @@ package = false
 
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "config.settings"
+pythonpath = ["."]
 python_files = ["test_*.py", "*_test.py"]
+testpaths = ["tests"]
 
 [tool.ruff]
 line-length = 100

--- a/src/scaffoldkit/blueprints/django-drf/templates/tests/__init__.py.j2
+++ b/src/scaffoldkit/blueprints/django-drf/templates/tests/__init__.py.j2
@@ -1,0 +1,1 @@
+"""Test suite for {{ display_name }}."""

--- a/src/scaffoldkit/blueprints/django-drf/templates/tests/test_health.py.j2
+++ b/src/scaffoldkit/blueprints/django-drf/templates/tests/test_health.py.j2
@@ -1,0 +1,20 @@
+"""Smoke tests for the DRF health endpoint and project wiring.
+
+Uses pytest-django. The health view performs no database access, so these
+tests run against the SQLite default with no live server.
+"""
+from django.test import Client
+
+
+def test_health_endpoint_returns_ok() -> None:
+    client = Client()
+    response = client.get("/api/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok", "service": "{{ project_name }}"}
+
+
+def test_health_view_imports_and_serializes() -> None:
+    from apps.api.serializers import HealthSerializer
+
+    data = HealthSerializer({"status": "ok", "service": "{{ project_name }}"}).data
+    assert data["status"] == "ok"

--- a/tests/test_django_drf_starter.py
+++ b/tests/test_django_drf_starter.py
@@ -1,0 +1,136 @@
+"""Regression tests for the django-drf runnable starter.
+
+These assert that the blueprint emits real, non-empty Django + DRF source (a
+runnable manage.py, a config package, an apps/api DRF app wired into the root
+URLconf, and a pytest-django smoke test), not just empty config/ and apps/
+directories. Companion to the runtime verification (`manage.py check` + the
+generated smoke test) recorded in PHASE3_LANE_A_REPORT_2026-06-02.md.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from scaffoldkit.blueprint_loader import load_blueprint
+from scaffoldkit.generator import generate
+from scaffoldkit.models import GenerationContext
+
+BLUEPRINTS_DIR = Path(__file__).resolve().parent.parent / "src" / "scaffoldkit" / "blueprints"
+
+_DEFAULTS = {
+    "project_name": "verify-django-drf",
+    "display_name": "Verify django-drf",
+    "description": "A Django REST Framework backend",
+    "python_version": "3.12",
+    "package_manager": "uv",
+    "database": "postgresql",
+    "auth_strategy": "jwt",
+    "use_docker": True,
+    "use_celery": False,
+    "use_channels": False,
+    "use_drf_spectacular": True,
+    "test_strategy": "pytest-django-and-integration",
+    "ai_context": True,
+}
+
+
+def _generate(tmp_path: Path, variables: dict) -> Path:
+    bp_path = BLUEPRINTS_DIR / "django-drf"
+    bp = load_blueprint(bp_path)
+    output = tmp_path / "output"
+    ctx = GenerationContext(
+        blueprint=bp,
+        blueprint_path=bp_path,
+        variables=variables,
+        target_dir=output,
+    )
+    result = generate(ctx)
+    assert result.success, f"Generation failed: {result.errors}"
+    return output
+
+
+# Source files the starter must emit, relative to the generated project root.
+_SOURCE_FILES = (
+    "manage.py",
+    "config/__init__.py",
+    "config/settings/__init__.py",
+    "config/urls.py",
+    "config/wsgi.py",
+    "config/asgi.py",
+    "apps/__init__.py",
+    "apps/api/__init__.py",
+    "apps/api/apps.py",
+    "apps/api/serializers.py",
+    "apps/api/views.py",
+    "apps/api/urls.py",
+    "apps/users/__init__.py",
+    "apps/users/apps.py",
+    "tests/__init__.py",
+    "tests/test_health.py",
+)
+
+
+class TestDjangoDrfStarter:
+    def test_emits_runnable_source_files(self, tmp_path: Path):
+        output = _generate(tmp_path, _DEFAULTS)
+        for rel in _SOURCE_FILES:
+            path = output / rel
+            assert path.exists(), f"missing starter file: {rel}"
+            # Non-empty and valid Python (catches accidental empty/garbled output).
+            text = path.read_text()
+            assert text.strip(), f"empty starter file: {rel}"
+            ast.parse(text)
+            # Jinja must be fully substituted, not left as literal {{ ... }}.
+            assert "{{" not in text, f"unrendered jinja in {rel}"
+
+    def test_manage_py_is_runnable_entry_point(self, tmp_path: Path):
+        output = _generate(tmp_path, _DEFAULTS)
+        manage = (output / "manage.py").read_text()
+        assert "execute_from_command_line" in manage
+        assert 'DJANGO_SETTINGS_MODULE", "config.settings"' in manage
+
+    def test_health_endpoint_is_wired_into_root_urlconf(self, tmp_path: Path):
+        output = _generate(tmp_path, _DEFAULTS)
+        root_urls = (output / "config" / "urls.py").read_text()
+        api_urls = (output / "apps" / "api" / "urls.py").read_text()
+        views = (output / "apps" / "api" / "views.py").read_text()
+        assert 'include("apps.api.urls")' in root_urls
+        assert 'path("api/"' in root_urls
+        assert "HealthView" in api_urls and "health" in api_urls
+        assert "class HealthView(APIView)" in views
+
+    def test_smoke_test_asserts_health_200(self, tmp_path: Path):
+        output = _generate(tmp_path, _DEFAULTS)
+        smoke = (output / "tests" / "test_health.py").read_text()
+        assert "/api/health" in smoke
+        assert "status_code == 200" in smoke
+        # The project name is interpolated into the expected response body.
+        assert "verify-django-drf" in smoke
+
+    def test_settings_default_to_sqlite_for_runnability(self, tmp_path: Path):
+        # Local/test DB must be SQLite so the starter runs with no live server,
+        # regardless of the declared production database engine.
+        output = _generate(tmp_path, _DEFAULTS)
+        settings = (output / "config" / "settings" / "__init__.py").read_text()
+        assert "django.db.backends.sqlite3" in settings
+        assert '"apps.api"' in settings and '"apps.users"' in settings
+
+    def test_drf_spectacular_gating_leaves_no_orphans(self, tmp_path: Path):
+        # With drf-spectacular disabled, the dep is not installed, so the
+        # settings/urls must not reference it (else the project fails to import).
+        output = _generate(tmp_path, {**_DEFAULTS, "use_drf_spectacular": False})
+        settings = (output / "config" / "settings" / "__init__.py").read_text()
+        root_urls = (output / "config" / "urls.py").read_text()
+        assert "drf_spectacular" not in settings
+        assert "spectacular" not in root_urls.lower()
+        # Source still parses and the app list is intact.
+        ast.parse(settings)
+        ast.parse(root_urls)
+
+    @pytest.mark.parametrize("auth_strategy", ["session", "jwt", "token", "oauth2", "none"])
+    def test_source_renders_for_all_auth_strategies(self, tmp_path: Path, auth_strategy: str):
+        output = _generate(tmp_path, {**_DEFAULTS, "auth_strategy": auth_strategy})
+        # The starter source is auth-agnostic and must always render cleanly.
+        for rel in ("config/settings/__init__.py", "apps/api/views.py", "manage.py"):
+            ast.parse((output / rel).read_text())


### PR DESCRIPTION
## What
The `django-drf` blueprint emitted 0 `.py` files (empty apps/config dirs), canMakeProgress=false.

## Fix
Emit a runnable Django project: `manage.py`, `config/settings/__init__.py`, `config/urls.py`, `config/wsgi.py`, `config/asgi.py`, an example DRF app (`apps/api` with a health view wired into the URLconf), and a pytest-django smoke test. Adds a per-blueprint regression test.

## Verification
`manage.py check` clean, `migrate` clean, live `runserver` returns 200 on `/api/health`, pytest-django smoke passes, scaffoldkit pytest (286) + `uv build` green. Rigorous review subagent: SHIP, 0 must-fix.

Refs: PHASE3_LANE_A_REPORT_2026-06-02.md