### PR TITLE
feat(rest-api): emit runnable express + django-rest starters

### DIFF
--- a/src/scaffoldkit/blueprints/rest-api/blueprint.yaml
+++ b/src/scaffoldkit/blueprints/rest-api/blueprint.yaml
@@ -140,20 +140,91 @@ templates:
     target: requirements-dev.txt
     condition: is_fastapi
 
+  # Minimal runnable Express/TypeScript starter (app factory, entry point, one
+  # example route, smoke test) so an express rest-api scaffold ships real source
+  # instead of an empty src/. Mirrors the fastapi starter, gated on is_express.
   - source: package.json.j2
     target: package.json
+    condition: is_express
+
+  - source: tsconfig.json.j2
+    target: tsconfig.json
+    condition: is_express
+
+  - source: src/app.ts.j2
+    target: src/app.ts
+    condition: is_express
+
+  - source: src/index.ts.j2
+    target: src/index.ts
+    condition: is_express
+
+  - source: src/routes/health.ts.j2
+    target: src/routes/health.ts
+    condition: is_express
+
+  - source: tests/health.test.ts.j2
+    target: tests/health.test.ts
     condition: is_express
 
   - source: pom.xml.j2
     target: pom.xml
     condition: is_spring_boot
 
+  # Minimal runnable Django REST Framework starter (settings, urls, wsgi, one
+  # example app with a health route, smoke test) so a django-rest rest-api
+  # scaffold ships a project that `python manage.py runserver` / `test` can
+  # actually boot, gated on is_django_rest.
   - source: django-manage.py.j2
     target: manage.py
     condition: is_django_rest
 
   - source: django-pyproject.toml.j2
     target: pyproject.toml
+    condition: is_django_rest
+
+  - source: django-requirements.txt.j2
+    target: requirements.txt
+    condition: is_django_rest
+
+  - source: django-config/__init__.py.j2
+    target: config/__init__.py
+    condition: is_django_rest
+
+  - source: django-config/settings.py.j2
+    target: config/settings.py
+    condition: is_django_rest
+
+  - source: django-config/urls.py.j2
+    target: config/urls.py
+    condition: is_django_rest
+
+  - source: django-config/wsgi.py.j2
+    target: config/wsgi.py
+    condition: is_django_rest
+
+  - source: django-api/__init__.py.j2
+    target: api/__init__.py
+    condition: is_django_rest
+
+  - source: django-api/apps.py.j2
+    target: api/apps.py
+    condition: is_django_rest
+
+  - source: django-api/views.py.j2
+    target: api/views.py
+    condition: is_django_rest
+
+  - source: django-api/urls.py.j2
+    target: api/urls.py
+    condition: is_django_rest
+
+  - source: django-tests/__init__.py.j2
+    target: tests/__init__.py
+    condition: is_django_rest
+
+  - source: django-tests/test_health.py.j2
+    target: tests/test_health.py
     condition: is_django_rest
 
   - source: .dockerignore.j2

--- a/src/scaffoldkit/blueprints/rest-api/templates/django-api/__init__.py.j2
+++ b/src/scaffoldkit/blueprints/rest-api/templates/django-api/__init__.py.j2
@@ -1,0 +1,1 @@
+"""Example API app for {{ display_name }}."""

--- a/src/scaffoldkit/blueprints/rest-api/templates/django-api/apps.py.j2
+++ b/src/scaffoldkit/blueprints/rest-api/templates/django-api/apps.py.j2
@@ -1,0 +1,7 @@
+"""App config for the example API app."""
+from django.apps import AppConfig
+
+
+class ApiConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "api"

--- a/src/scaffoldkit/blueprints/rest-api/templates/django-api/urls.py.j2
+++ b/src/scaffoldkit/blueprints/rest-api/templates/django-api/urls.py.j2
@@ -1,0 +1,9 @@
+"""URL routes for the example API app."""
+from django.urls import path
+
+from api import views
+
+urlpatterns = [
+    path("", views.root),
+    path("health", views.health, name="health"),
+]

--- a/src/scaffoldkit/blueprints/rest-api/templates/django-api/views.py.j2
+++ b/src/scaffoldkit/blueprints/rest-api/templates/django-api/views.py.j2
@@ -1,0 +1,16 @@
+"""Example API views for {{ display_name }}."""
+from rest_framework.decorators import api_view
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+
+@api_view(["GET"])
+def health(_request: Request) -> Response:
+    """Liveness probe used by orchestration and smoke tests."""
+    return Response({"status": "ok"})
+
+
+@api_view(["GET"])
+def root(_request: Request) -> Response:
+    """Return a small service descriptor for the API root."""
+    return Response({"service": "{{ project_name }}", "status": "ok"})

--- a/src/scaffoldkit/blueprints/rest-api/templates/django-config/__init__.py.j2
+++ b/src/scaffoldkit/blueprints/rest-api/templates/django-config/__init__.py.j2
@@ -1,0 +1,1 @@
+"""{{ display_name }} Django project configuration package."""

--- a/src/scaffoldkit/blueprints/rest-api/templates/django-config/settings.py.j2
+++ b/src/scaffoldkit/blueprints/rest-api/templates/django-config/settings.py.j2
@@ -1,0 +1,46 @@
+"""Minimal Django REST Framework settings for {{ display_name }}.
+
+This is a thin, runnable starter. Replace SECRET_KEY, lock down DEBUG and
+ALLOWED_HOSTS, and point DATABASES at {{ database }} before deploying.
+"""
+import os
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+
+SECRET_KEY = os.environ.get("SECRET_KEY", "change-me-in-production")
+DEBUG = os.environ.get("DEBUG", "true").lower() == "true"
+ALLOWED_HOSTS = os.environ.get("ALLOWED_HOSTS", "*").split(",")
+
+INSTALLED_APPS = [
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.staticfiles",
+    "rest_framework",
+    "api",
+]
+
+MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
+    "django.middleware.common.CommonMiddleware",
+]
+
+REST_FRAMEWORK = {
+    "DEFAULT_AUTHENTICATION_CLASSES": [],
+    "DEFAULT_PERMISSION_CLASSES": ["rest_framework.permissions.AllowAny"],
+}
+
+ROOT_URLCONF = "config.urls"
+
+WSGI_APPLICATION = "config.wsgi.application"
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": BASE_DIR / "db.sqlite3",
+    }
+}
+
+STATIC_URL = "/static/"
+
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"

--- a/src/scaffoldkit/blueprints/rest-api/templates/django-config/urls.py.j2
+++ b/src/scaffoldkit/blueprints/rest-api/templates/django-config/urls.py.j2
@@ -1,0 +1,6 @@
+"""Root URL configuration for {{ display_name }}."""
+from django.urls import include, path
+
+urlpatterns = [
+    path("", include("api.urls")),
+]

--- a/src/scaffoldkit/blueprints/rest-api/templates/django-config/wsgi.py.j2
+++ b/src/scaffoldkit/blueprints/rest-api/templates/django-config/wsgi.py.j2
@@ -1,0 +1,8 @@
+"""WSGI entry point for {{ display_name }}."""
+import os
+
+from django.core.wsgi import get_wsgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+
+application = get_wsgi_application()

--- a/src/scaffoldkit/blueprints/rest-api/templates/django-requirements.txt.j2
+++ b/src/scaffoldkit/blueprints/rest-api/templates/django-requirements.txt.j2
@@ -1,0 +1,2 @@
+django>=5.1.7,<5.2.0
+djangorestframework>=3.15.2,<4.0.0

--- a/src/scaffoldkit/blueprints/rest-api/templates/django-tests/__init__.py.j2
+++ b/src/scaffoldkit/blueprints/rest-api/templates/django-tests/__init__.py.j2
@@ -1,0 +1,1 @@
+"""Test suite for {{ project_name }}."""

--- a/src/scaffoldkit/blueprints/rest-api/templates/django-tests/test_health.py.j2
+++ b/src/scaffoldkit/blueprints/rest-api/templates/django-tests/test_health.py.j2
@@ -1,0 +1,23 @@
+"""Smoke tests for the health route and application wiring.
+
+Run with the Django test runner:
+
+    python manage.py test
+"""
+from django.test import TestCase
+from django.urls import reverse
+
+
+class HealthRouteTests(TestCase):
+    def test_health_returns_ok(self) -> None:
+        response = self.client.get("/health")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"status": "ok"})
+
+    def test_health_route_is_registered(self) -> None:
+        self.assertEqual(reverse("health"), "/health")
+
+    def test_root_returns_service_descriptor(self) -> None:
+        response = self.client.get("/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["status"], "ok")

--- a/src/scaffoldkit/blueprints/rest-api/templates/package.json.j2
+++ b/src/scaffoldkit/blueprints/rest-api/templates/package.json.j2
@@ -2,11 +2,13 @@
   "name": "{{ project_name }}",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "tsc -p tsconfig.json",
     "start": "node dist/index.js",
-    "test": "node --test"
+    "test": "node --import tsx --test tests/**/*.test.ts",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
     "express": "^4.21.2"

--- a/src/scaffoldkit/blueprints/rest-api/templates/src/app.ts.j2
+++ b/src/scaffoldkit/blueprints/rest-api/templates/src/app.ts.j2
@@ -1,0 +1,23 @@
+import express, { type Express, type Request, type Response } from "express";
+
+import { healthRouter } from "./routes/health.js";
+
+/**
+ * Build the {{ display_name }} Express application.
+ *
+ * The app is created without binding to a port so tests can import it
+ * directly. The entry point in src/index.ts is responsible for calling
+ * `app.listen()`.
+ */
+export function createApp(): Express {
+  const app = express();
+  app.use(express.json());
+
+  app.get("/", (_req: Request, res: Response) => {
+    res.json({ service: "{{ project_name }}", status: "ok" });
+  });
+
+  app.use(healthRouter);
+
+  return app;
+}

--- a/src/scaffoldkit/blueprints/rest-api/templates/src/index.ts.j2
+++ b/src/scaffoldkit/blueprints/rest-api/templates/src/index.ts.j2
@@ -1,0 +1,9 @@
+import { createApp } from "./app.js";
+
+const port = Number(process.env.PORT ?? 3000);
+const app = createApp();
+
+app.listen(port, () => {
+  // eslint-disable-next-line no-console
+  console.log(`{{ display_name }} listening on http://localhost:${port}`);
+});

--- a/src/scaffoldkit/blueprints/rest-api/templates/src/routes/health.ts.j2
+++ b/src/scaffoldkit/blueprints/rest-api/templates/src/routes/health.ts.j2
@@ -1,0 +1,8 @@
+import { Router, type Request, type Response } from "express";
+
+export const healthRouter = Router();
+
+/** Liveness probe used by orchestration and smoke tests. */
+healthRouter.get("/health", (_req: Request, res: Response) => {
+  res.json({ status: "ok" });
+});

--- a/src/scaffoldkit/blueprints/rest-api/templates/tests/health.test.ts.j2
+++ b/src/scaffoldkit/blueprints/rest-api/templates/tests/health.test.ts.j2
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import type { AddressInfo } from "node:net";
+import { after, before, test } from "node:test";
+
+import { createApp } from "../src/app.js";
+
+let baseUrl: string;
+let server: ReturnType<ReturnType<typeof createApp>["listen"]>;
+
+before(async () => {
+  const app = createApp();
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, () => resolve());
+  });
+  const { port } = server.address() as AddressInfo;
+  baseUrl = `http://127.0.0.1:${port}`;
+});
+
+after(async () => {
+  await new Promise<void>((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+});
+
+test("GET /health returns ok", async () => {
+  const res = await fetch(`${baseUrl}/health`);
+  assert.equal(res.status, 200);
+  assert.deepEqual(await res.json(), { status: "ok" });
+});
+
+test("GET / returns a service descriptor", async () => {
+  const res = await fetch(`${baseUrl}/`);
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as { service: string; status: string };
+  assert.equal(body.status, "ok");
+  assert.equal(typeof body.service, "string");
+});

--- a/src/scaffoldkit/blueprints/rest-api/templates/tsconfig.json.j2
+++ b/src/scaffoldkit/blueprints/rest-api/templates/tsconfig.json.j2
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "declaration": false
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/tests/test_rest_api_starter.py
+++ b/tests/test_rest_api_starter.py
@@ -1,0 +1,155 @@
+"""Regression tests for the rest-api blueprint runnable starters.
+
+Asserts that each framework path that the blueprint claims to support emits a
+real, non-empty entry point + example route + smoke test instead of empty src/
+directories. Mirrors the bar set by the fastapi starter (scaffoldkit #48) and
+the symfony-backend starter (PR #52).
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from scaffoldkit.blueprint_loader import load_blueprint
+from scaffoldkit.generator import generate
+from scaffoldkit.models import GenerationContext
+from scaffoldkit.planforge import default_variables_for_blueprint
+
+BLUEPRINTS_DIR = Path(__file__).resolve().parent.parent / "src" / "scaffoldkit" / "blueprints"
+
+
+def _generate(tmp_path: Path, variables: dict) -> Path:
+    bp_path = BLUEPRINTS_DIR / "rest-api"
+    bp = load_blueprint(bp_path)
+    # Seed declared defaults the way the CLI does, then apply the test overrides.
+    merged = {**default_variables_for_blueprint(bp), **_BASE, **variables}
+    output = tmp_path / "output"
+    ctx = GenerationContext(
+        blueprint=bp,
+        blueprint_path=bp_path,
+        variables=merged,
+        target_dir=output,
+    )
+    result = generate(ctx)
+    assert result.success, f"Generation failed: {result.errors}"
+    return output
+
+
+_BASE = {
+    "project_name": "verify-rest-api",
+    "display_name": "Verify rest-api",
+    "description": "A test REST API",
+}
+
+
+def _assert_nonempty(path: Path) -> str:
+    assert path.exists(), f"expected file missing: {path}"
+    text = path.read_text()
+    assert text.strip(), f"expected non-empty file: {path}"
+    assert "{{" not in text, f"unrendered Jinja in {path}: {text[:200]}"
+    return text
+
+
+class TestFastapiStarter:
+    """The default (fastapi) path must keep shipping its runnable starter."""
+
+    def test_emits_runnable_python_source(self, tmp_path: Path):
+        output = _generate(tmp_path, {**_BASE, "framework": "fastapi"})
+        main = _assert_nonempty(output / "src" / "main.py")
+        route = _assert_nonempty(output / "src" / "routes" / "health.py")
+        smoke = _assert_nonempty(output / "tests" / "test_health.py")
+        for source in (main, route, smoke):
+            ast.parse(source)
+        assert "FastAPI" in main
+        assert "/health" in route
+        assert "Verify rest-api" in main
+
+
+class TestExpressStarter:
+    """The express path must emit a runnable TypeScript starter, not empty src/."""
+
+    def test_emits_runnable_typescript_source(self, tmp_path: Path):
+        output = _generate(tmp_path, {**_BASE, "framework": "express"})
+        app = _assert_nonempty(output / "src" / "app.ts")
+        index = _assert_nonempty(output / "src" / "index.ts")
+        route = _assert_nonempty(output / "src" / "routes" / "health.ts")
+        smoke = _assert_nonempty(output / "tests" / "health.test.ts")
+        pkg = _assert_nonempty(output / "package.json")
+        _assert_nonempty(output / "tsconfig.json")
+
+        assert "createApp" in app
+        assert "express" in app
+        assert "createApp" in index
+        assert "/health" in route
+        assert "createApp" in smoke
+        assert "verify-rest-api" in app
+        # The package wires the declared scripts to the emitted source.
+        assert '"build"' in pkg
+        assert '"test"' in pkg
+        assert '"type": "module"' in pkg
+
+    def test_no_orphan_python_starter_on_express(self, tmp_path: Path):
+        output = _generate(tmp_path, {**_BASE, "framework": "express"})
+        assert not (output / "src" / "main.py").exists()
+        assert not (output / "tests" / "test_health.py").exists()
+        assert not (output / "requirements.txt").exists()
+
+
+class TestDjangoRestStarter:
+    """The django-rest path must emit a bootable Django project, not empty src/."""
+
+    def test_emits_runnable_django_project(self, tmp_path: Path):
+        output = _generate(tmp_path, {**_BASE, "framework": "django-rest"})
+        settings = _assert_nonempty(output / "config" / "settings.py")
+        urls = _assert_nonempty(output / "config" / "urls.py")
+        _assert_nonempty(output / "config" / "wsgi.py")
+        _assert_nonempty(output / "config" / "__init__.py")
+        views = _assert_nonempty(output / "api" / "views.py")
+        api_urls = _assert_nonempty(output / "api" / "urls.py")
+        _assert_nonempty(output / "api" / "apps.py")
+        smoke = _assert_nonempty(output / "tests" / "test_health.py")
+        manage = _assert_nonempty(output / "manage.py")
+        _assert_nonempty(output / "requirements.txt")
+
+        for source in (settings, urls, views, api_urls, smoke, manage):
+            ast.parse(source)
+        # The manage.py settings module and the urlconf must agree.
+        assert "config.settings" in manage
+        assert "config.settings" in settings or "ROOT_URLCONF" in settings
+        assert "api.urls" in urls
+        assert "/health" in smoke
+        assert "health" in views
+        assert "django" in (output / "requirements.txt").read_text().lower()
+
+    def test_no_orphan_fastapi_starter_on_django(self, tmp_path: Path):
+        output = _generate(tmp_path, {**_BASE, "framework": "django-rest"})
+        assert not (output / "src" / "main.py").exists()
+        assert not (output / "package.json").exists()
+
+
+class TestSpringBootScopedOut:
+    """spring-boot is intentionally left as a manifest-only shell here.
+
+    A runnable spring-boot starter is redundant with the dedicated
+    springboot-backend blueprint and is not buildable in the CI toolchain
+    (no JDK/Maven). The path still emits pom.xml + docs, just no src/.
+    """
+
+    def test_no_partial_java_source(self, tmp_path: Path):
+        output = _generate(tmp_path, {**_BASE, "framework": "spring-boot"})
+        assert (output / "pom.xml").exists()
+        java_sources = list(output.rglob("*.java"))
+        assert java_sources == [], f"unexpected half-built java starter: {java_sources}"
+
+
+@pytest.mark.parametrize("framework", ["fastapi", "express", "django-rest", "spring-boot"])
+def test_every_framework_path_renders(tmp_path: Path, framework: str):
+    """No framework choice leaves orphan or unrendered template files."""
+    output = _generate(tmp_path, {**_BASE, "framework": framework})
+    assert (output / "README.md").exists()
+    for rendered in output.rglob("*"):
+        if rendered.is_file():
+            assert "{{" not in rendered.read_text(errors="ignore"), (
+                f"unrendered Jinja in {rendered}"
+            )


### PR DESCRIPTION
## What
The generic `rest-api` blueprint emitted real source only on the fastapi path (#48); the express and django-rest framework branches left `src/` empty.

## Fix
Emit thin runnable starters for the express and django-rest framework options (entry + example route + smoke test), gated per framework. The fastapi path is untouched.

## Verification
express: `npm run build` (tsc strict) + smoke test + `node dist/index.js` serves `/health`. django-rest: `manage.py test` + `runserver` returns 200 on `/health`. scaffoldkit pytest (285) + `uv build` green; a regression test asserts no wrong-framework leakage. Rigorous review subagent: SHIP, 0 must-fix.

Refs: PHASE3_LANE_A_REPORT_2026-06-02.md