### PR TITLE
feat(springboot-backend): emit vertical-slice starter, fix application.yml, add mvnw

### DIFF
--- a/src/scaffoldkit/blueprints/springboot-backend/blueprint.yaml
+++ b/src/scaffoldkit/blueprints/springboot-backend/blueprint.yaml
@@ -153,8 +153,54 @@ templates:
   - source: src/main/java/Application.java.j2
     target: src/main/java/{{ base_package | replace('.', '/') }}/Application.java
 
+  - source: src/main/java/web/HealthController.java.j2
+    target: src/main/java/{{ base_package | replace('.', '/') }}/web/HealthController.java
+
+  - source: src/main/java/web/dto/HealthResponse.java.j2
+    target: src/main/java/{{ base_package | replace('.', '/') }}/web/dto/HealthResponse.java
+
+  - source: src/main/java/service/HealthService.java.j2
+    target: src/main/java/{{ base_package | replace('.', '/') }}/service/HealthService.java
+
+  - source: src/main/java/domain/Widget.java.j2
+    target: src/main/java/{{ base_package | replace('.', '/') }}/domain/Widget.java
+
+  - source: src/main/java/repository/WidgetRepository.java.j2
+    target: src/main/java/{{ base_package | replace('.', '/') }}/repository/WidgetRepository.java
+
+  - source: src/main/java/security/SecurityConfig.java.j2
+    target: src/main/java/{{ base_package | replace('.', '/') }}/security/SecurityConfig.java
+    condition: is_spring_mvc_auth
+
+  - source: src/main/java/security/SecurityConfigReactive.java.j2
+    target: src/main/java/{{ base_package | replace('.', '/') }}/security/SecurityConfig.java
+    condition: is_webflux_auth
+
   - source: src/main/resources/application.yml.j2
     target: src/main/resources/application.yml
+
+  - source: src/test/java/HealthControllerSmokeTest.java.j2
+    target: src/test/java/{{ base_package | replace('.', '/') }}/HealthControllerSmokeTest.java
+    condition: is_spring_mvc
+
+  - source: src/test/java/HealthControllerReactiveSmokeTest.java.j2
+    target: src/test/java/{{ base_package | replace('.', '/') }}/HealthControllerSmokeTest.java
+    condition: is_webflux
+
+  - source: src/test/resources/application.yml.j2
+    target: src/test/resources/application.yml
+
+  - source: mvnw.j2
+    target: mvnw
+    condition: is_maven
+
+  - source: mvnw.cmd.j2
+    target: mvnw.cmd
+    condition: is_maven
+
+  - source: .mvn/wrapper/maven-wrapper.properties.j2
+    target: .mvn/wrapper/maven-wrapper.properties
+    condition: is_maven
 
   - source: .dockerignore.j2
     target: .dockerignore

--- a/src/scaffoldkit/blueprints/springboot-backend/templates/.mvn/wrapper/maven-wrapper.properties.j2
+++ b/src/scaffoldkit/blueprints/springboot-backend/templates/.mvn/wrapper/maven-wrapper.properties.j2
@@ -1,0 +1,2 @@
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.2/maven-wrapper-3.3.2.jar

--- a/src/scaffoldkit/blueprints/springboot-backend/templates/build.gradle.j2
+++ b/src/scaffoldkit/blueprints/springboot-backend/templates/build.gradle.j2
@@ -41,6 +41,10 @@ dependencies {
   runtimeOnly "org.mariadb.jdbc:mariadb-java-client"
 {% endif -%}
   testImplementation "org.springframework.boot:spring-boot-starter-test"
+{% if use_auth -%}
+  testImplementation "org.springframework.security:spring-security-test"
+{% endif -%}
+  testRuntimeOnly "com.h2database:h2"
 {% if test_strategy != "junit-only" -%}
   testImplementation "org.testcontainers:junit-jupiter"
 {% endif -%}

--- a/src/scaffoldkit/blueprints/springboot-backend/templates/mvnw.cmd.j2
+++ b/src/scaffoldkit/blueprints/springboot-backend/templates/mvnw.cmd.j2
@@ -1,0 +1,147 @@
+<# : batch portion
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one or more
+@REM contributor license agreements.  See the NOTICE file distributed with
+@REM this work for additional information regarding copyright ownership.
+@REM The ASF licenses this file to You under the Apache License, Version 2.0
+@REM (the "License"); you may not use this file except in compliance with
+@REM the License.  You may obtain a copy of the License at
+@REM
+@REM    https://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing, software
+@REM distributed under the License is distributed on an "AS IS" BASIS,
+@REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@REM See the License for the specific language governing permissions and
+@REM limitations under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Apache Maven Wrapper startup batch script, version 3.3.2
+@REM
+@REM Optional ENV vars
+@REM   MVNW_REPOURL - repo url base for downloading maven distribution
+@REM   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+@REM   MVNW_VERBOSE - true: enable verbose log; others: silence the output
+@REM ----------------------------------------------------------------------------
+
+@IF "%__MVNW_ARG0_NAME__%"=="" (SET __MVNW_ARG0_NAME__=%~nx0)
+@SET __MVNW_CMD__=
+@SET __MVNW_ERROR__=
+@SET __MVNW_PSMODULEP_SAVE=%PSModulePath%
+@SET PSModulePath=
+@FOR /F "usebackq tokens=1* delims==" %%A IN (`powershell -noprofile "& {$scriptDir='%~dp0'; $script='%__MVNW_ARG0_NAME__%'; icm -ScriptBlock ([Scriptblock]::Create((Get-Content -Raw '%~f0'))) -NoNewScope}"`) DO @(
+  IF "%%A"=="MVN_CMD" (set __MVNW_CMD__=%%B) ELSE IF "%%B"=="" (echo %%A) ELSE (echo %%A=%%B)
+)
+@SET PSModulePath=%__MVNW_PSMODULEP_SAVE%
+@SET __MVNW_PSMODULEP_SAVE=
+@SET __MVNW_ARG0_NAME__=
+@SET MVNW_USERNAME=
+@SET MVNW_PASSWORD=
+@IF NOT "%__MVNW_CMD__%"=="" (%__MVNW_CMD__% %*)
+@echo Cannot start maven from wrapper >&2 && exit /b 1
+@GOTO :EOF
+: end batch / begin powershell #>
+
+$ErrorActionPreference = "Stop"
+if ($env:MVNW_VERBOSE -eq "true") {
+  $VerbosePreference = "Continue"
+}
+
+# calculate distributionUrl, requires .mvn/wrapper/maven-wrapper.properties
+$distributionUrl = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionUrl
+if (!$distributionUrl) {
+  Write-Error "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+}
+
+switch -wildcard -casesensitive ( $($distributionUrl -replace '^.*/','') ) {
+  "maven-mvnd-*" {
+    $USE_MVND = $true
+    $distributionUrl = $distributionUrl -replace '-bin\.[^.]*$',"-windows-amd64.zip"
+    $MVN_CMD = "mvnd.cmd"
+    break
+  }
+  default {
+    $USE_MVND = $false
+    $MVN_CMD = $script -replace '^mvnw','mvn'
+    break
+  }
+}
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+if ($env:MVNW_REPOURL) {
+  $MVNW_REPO_PATTERN = if ($USE_MVND) { "/org/apache/maven/" } else { "/maven/mvnd/" }
+  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace '^.*'+$MVNW_REPO_PATTERN,'')"
+}
+$distributionUrlName = $distributionUrl -replace '^.*/',''
+$distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''
+$MAVEN_HOME_PARENT = "$HOME/.m2/wrapper/dists/$distributionUrlNameMain"
+if ($env:MAVEN_USER_HOME) {
+  $MAVEN_HOME_PARENT = "$env:MAVEN_USER_HOME/wrapper/dists/$distributionUrlNameMain"
+}
+$MAVEN_HOME_NAME = ([System.Security.Cryptography.MD5]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
+$MAVEN_HOME = "$MAVEN_HOME_PARENT/$MAVEN_HOME_NAME"
+
+if (Test-Path -Path "$MAVEN_HOME" -PathType Container) {
+  Write-Verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"
+  exit $?
+}
+
+if (! $distributionUrlNameMain -or ($distributionUrlName -eq $distributionUrlNameMain)) {
+  Write-Error "distributionUrl is not valid, must end with *-bin.zip, but found $distributionUrl"
+}
+
+# prepare tmp dir
+$TMP_DOWNLOAD_DIR_HOLDER = New-TemporaryFile
+$TMP_DOWNLOAD_DIR = New-Item -Itemtype Directory -Path "$TMP_DOWNLOAD_DIR_HOLDER.dir"
+$TMP_DOWNLOAD_DIR_HOLDER.Delete() | Out-Null
+trap {
+  if ($TMP_DOWNLOAD_DIR.Exists) {
+    try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+    catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+  }
+}
+
+New-Item -Itemtype Directory -Path "$MAVEN_HOME_PARENT" -Force | Out-Null
+
+# Download and Install Apache Maven
+Write-Verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+Write-Verbose "Downloading from: $distributionUrl"
+Write-Verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+$webclient = New-Object System.Net.WebClient
+if ($env:MVNW_USERNAME -and $env:MVNW_PASSWORD) {
+  $webclient.Credentials = New-Object System.Net.NetworkCredential($env:MVNW_USERNAME, $env:MVNW_PASSWORD)
+}
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$webclient.DownloadFile($distributionUrl, "$TMP_DOWNLOAD_DIR/$distributionUrlName") | Out-Null
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+$distributionSha256Sum = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionSha256Sum
+if ($distributionSha256Sum) {
+  if ($USE_MVND) {
+    Write-Error "Checksum validation is not supported for maven-mvnd. `nPlease disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties."
+  }
+  Import-Module $PSHOME\Modules\Microsoft.PowerShell.Utility -Function Get-FileHash
+  if ((Get-FileHash "$TMP_DOWNLOAD_DIR/$distributionUrlName" -Algorithm SHA256).Hash.ToLower() -ne $distributionSha256Sum) {
+    Write-Error "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised. If you updated your Maven version, you need to update the specified distributionSha256Sum property."
+  }
+}
+
+# unzip and move
+Expand-Archive "$TMP_DOWNLOAD_DIR/$distributionUrlName" -DestinationPath "$TMP_DOWNLOAD_DIR" | Out-Null
+Rename-Item -Path "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" -NewName $MAVEN_HOME_NAME | Out-Null
+try {
+  Move-Item -Path "$TMP_DOWNLOAD_DIR/$MAVEN_HOME_NAME" -Destination $MAVEN_HOME_PARENT | Out-Null
+} catch {
+  if (! (Test-Path -Path "$MAVEN_HOME" -PathType Container)) {
+    Write-Error "fail to move MAVEN_HOME"
+  }
+} finally {
+  try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+  catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+}
+
+Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"

--- a/src/scaffoldkit/blueprints/springboot-backend/templates/mvnw.j2
+++ b/src/scaffoldkit/blueprints/springboot-backend/templates/mvnw.j2
@@ -1,0 +1,257 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.3.2
+#
+# Optional ENV vars
+# -----------------
+#   JAVA_HOME - location of a JDK home dir, required when download maven via java source
+#   MVNW_REPOURL - repo url base for downloading maven distribution
+#   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+#   MVNW_VERBOSE - true: enable verbose log; debug: trace the mvnw script; others: silence the output
+# ----------------------------------------------------------------------------
+
+set -euf
+[ "${MVNW_VERBOSE-}" != debug ] || set -x
+
+# OS specific support.
+native_path() { printf %s\\n "$1"; }
+case "$(uname)" in
+CYGWIN* | MINGW*)
+  [ -z "${JAVA_HOME-}" ] || JAVA_HOME="$(cygpath --unix "$JAVA_HOME")"
+  native_path() { cygpath --path --windows "$1"; }
+  ;;
+esac
+
+# set JAVACMD and JAVACCMD
+set_java_home() {
+  # For Cygwin and MinGW, ensure paths are in Unix format before anything is touched
+  if [ -n "${JAVA_HOME-}" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+      JAVACCMD="$JAVA_HOME/jre/sh/javac"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+      JAVACCMD="$JAVA_HOME/bin/javac"
+
+      if [ ! -x "$JAVACMD" ] || [ ! -x "$JAVACCMD" ]; then
+        echo "The JAVA_HOME environment variable is not defined correctly, so mvnw cannot run." >&2
+        echo "JAVA_HOME is set to \"$JAVA_HOME\", but \"\$JAVA_HOME/bin/java\" or \"\$JAVA_HOME/bin/javac\" does not exist." >&2
+        return 1
+      fi
+    fi
+  else
+    JAVACMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v java
+    )" || :
+    JAVACCMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v javac
+    )" || :
+
+    if [ ! -x "${JAVACMD-}" ] || [ ! -x "${JAVACCMD-}" ]; then
+      echo "The java/javac command does not exist in PATH nor is JAVA_HOME set, so mvnw cannot run." >&2
+      return 1
+    fi
+  fi
+}
+
+# hash string like Java String::hashCode
+hash_string() {
+  str="${1:-}" h=0
+  while [ -n "$str" ]; do
+    char="${str%"${str#?}"}"
+    h=$(((h * 31 + $(LC_CTYPE=C printf %d "'$char")) % 4294967296))
+    str="${str#?}"
+  done
+  printf %x\\n $h
+}
+
+verbose() { :; }
+[ "${MVNW_VERBOSE-}" != true ] || verbose() { printf %s\\n "${1-}"; }
+
+die() {
+  printf %s\\n "$1" >&2
+  exit 1
+}
+
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, and line feeds.
+  #   Needed because sh.exe to bash on Windows shows '\r\n' as line ending.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
+# parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
+while IFS="=" read -r key value; do
+  case "${key-}" in
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
+  esac
+done <"${0%/*}/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in ${0%/*}/.mvn/wrapper/maven-wrapper.properties"
+
+case "${distributionUrl##*/}" in
+maven-mvnd-*bin.*)
+  MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/
+  case "${PROCESSOR_ARCHITECTURE-}${PROCESSOR_ARCHITEW6432-}:$(uname -a)" in
+  *AMD64:CYGWIN* | *AMD64:MINGW*) distributionPlatform=windows-amd64 ;;
+  :Darwin*x86_64) distributionPlatform=darwin-amd64 ;;
+  :Darwin*arm64) distributionPlatform=darwin-aarch64 ;;
+  :Linux*x86_64*) distributionPlatform=linux-amd64 ;;
+  *)
+    echo "Cannot detect native platform for mvnd on $(uname)-$(uname -m), use pure java version" >&2
+    distributionPlatform=linux-amd64
+    ;;
+  esac
+  distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
+  ;;
+maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
+*) MVN_CMD="mvn${0##*/mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+esac
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+[ -z "${MVNW_REPOURL-}" ] || distributionUrl="$MVNW_REPOURL$_MVNW_REPO_PATTERN${distributionUrl#*"$_MVNW_REPO_PATTERN"}"
+distributionUrlName="${distributionUrl##*/}"
+distributionUrlNameMain="${distributionUrlName%.*}"
+distributionUrlNameMain="${distributionUrlNameMain%-bin}"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
+
+exec_maven() {
+  unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :
+  exec "$MAVEN_HOME/bin/$MVN_CMD" "$@" || die "cannot exec $MAVEN_HOME/bin/$MVN_CMD"
+}
+
+if [ -d "$MAVEN_HOME" ]; then
+  verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  exec_maven "$@"
+fi
+
+case "${distributionUrl-}" in
+*?-bin.zip | *?maven-mvnd-?*-?*.zip) ;;
+*) die "distributionUrl is not valid, must match *-bin.zip or maven-mvnd-*.zip, but found '${distributionUrl-}'" ;;
+esac
+
+# prepare tmp dir
+if TMP_DOWNLOAD_DIR="$(mktemp -d)" && [ -d "$TMP_DOWNLOAD_DIR" ]; then
+  clean() { rm -rf -- "$TMP_DOWNLOAD_DIR"; }
+  trap clean HUP INT TERM EXIT
+else
+  die "cannot create temp dir"
+fi
+
+mkdir -p -- "${MAVEN_HOME%/*}"
+
+# Download and Install Apache Maven
+verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+verbose "Downloading from: $distributionUrl"
+verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+# select .zip or .tar.gz
+if ! command -v unzip >/dev/null; then
+  verbose "unzip not found, downloading and using the .tar.gz distribution"
+  distributionUrl="${distributionUrl%.zip}.tar.gz"
+  distributionUrlName="${distributionUrl##*/}"
+fi
+
+# verbose opt
+__MVNW_QUIET_WGET=--quiet __MVNW_QUIET_CURL=--silent __MVNW_QUIET_UNZIP=-q __MVNW_QUIET_TAR=''
+[ "${MVNW_VERBOSE-}" != true ] || __MVNW_QUIET_WGET='' __MVNW_QUIET_CURL='' __MVNW_QUIET_UNZIP='' __MVNW_QUIET_TAR=v
+
+# normalize http auth
+case "${MVNW_PASSWORD:+has-password}" in
+'') MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+has-password) [ -n "${MVNW_USERNAME-}" ] || MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+esac
+
+if [ -z "${MVNW_USERNAME-}" ] && command -v wget >/dev/null; then
+  verbose "Found wget ... using wget"
+  wget ${__MVNW_QUIET_WGET:+"$__MVNW_QUIET_WGET"} "$distributionUrl" -O "$TMP_DOWNLOAD_DIR/$distributionUrlName" || die "wget: Failed to fetch $distributionUrl"
+elif [ -z "${MVNW_USERNAME-}" ] && command -v curl >/dev/null; then
+  verbose "Found curl ... using curl"
+  curl ${__MVNW_QUIET_CURL:+"$__MVNW_QUIET_CURL"} -f -L -o "$TMP_DOWNLOAD_DIR/$distributionUrlName" "$distributionUrl" || die "curl: Failed to fetch $distributionUrl"
+elif set_java_home; then
+  verbose "Falling back to use Java to download"
+  javaSource="$TMP_DOWNLOAD_DIR/Downloader.java"
+  targetZip="$TMP_DOWNLOAD_DIR/$distributionUrlName"
+  cat >"$javaSource" <<-END
+	public class Downloader extends java.net.Authenticator
+	{
+	  protected java.net.PasswordAuthentication getPasswordAuthentication()
+	  {
+	    return new java.net.PasswordAuthentication( System.getenv( "MVNW_USERNAME" ), System.getenv( "MVNW_PASSWORD" ).toCharArray() );
+	  }
+	  public static void main( String[] args ) throws Exception
+	  {
+	    setDefault( new Downloader() );
+	    java.nio.file.Files.copy( java.net.URI.create( args[0] ).toURL().openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
+	  }
+	}
+	END
+  # For Cygwin/MinGW, switch paths to Windows format before running javac and java
+  verbose " - Compiling Downloader.java ..."
+  "$(native_path "$JAVACCMD")" "$(native_path "$javaSource")" || die "Failed to compile Downloader.java"
+  verbose " - Running Downloader.java ..."
+  "$(native_path "$JAVACMD")" -cp "$(native_path "$TMP_DOWNLOAD_DIR")" Downloader "$distributionUrl" "$(native_path "$targetZip")"
+fi
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+if [ -n "${distributionSha256Sum-}" ]; then
+  distributionSha256Result=false
+  if [ "$MVN_CMD" = mvnd.sh ]; then
+    echo "Checksum validation is not supported for maven-mvnd." >&2
+    echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  elif command -v sha256sum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  elif command -v shasum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | shasum -a 256 -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  fi
+  if [ $distributionSha256Result = false ]; then
+    echo "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised." >&2
+    echo "If you updated your Maven version, you need to update the specified distributionSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+# unzip and move
+if command -v unzip >/dev/null; then
+  unzip ${__MVNW_QUIET_UNZIP:+"$__MVNW_QUIET_UNZIP"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -d "$TMP_DOWNLOAD_DIR" || die "failed to unzip"
+else
+  tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
+fi
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+clean || :
+exec_maven "$@"

--- a/src/scaffoldkit/blueprints/springboot-backend/templates/pom.xml.j2
+++ b/src/scaffoldkit/blueprints/springboot-backend/templates/pom.xml.j2
@@ -81,6 +81,18 @@
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
+{% if use_auth -%}
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+{% endif -%}
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>test</scope>
+    </dependency>
 {% if test_strategy != "junit-only" -%}
     <dependency>
       <groupId>org.testcontainers</groupId>

--- a/src/scaffoldkit/blueprints/springboot-backend/templates/src/main/java/domain/Widget.java.j2
+++ b/src/scaffoldkit/blueprints/springboot-backend/templates/src/main/java/domain/Widget.java.j2
@@ -1,0 +1,44 @@
+package {{ base_package }}.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+/**
+ * Example domain entity.
+ *
+ * <p>Replace this with your real aggregate roots. It exists so the persistence
+ * layer has a mapped table to validate the JPA/Spring Data wiring end to end.
+ */
+@Entity
+@Table(name = "widgets")
+public class Widget {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    protected Widget() {
+        // Required by JPA.
+    }
+
+    public Widget(String name) {
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/src/scaffoldkit/blueprints/springboot-backend/templates/src/main/java/repository/WidgetRepository.java.j2
+++ b/src/scaffoldkit/blueprints/springboot-backend/templates/src/main/java/repository/WidgetRepository.java.j2
@@ -1,0 +1,13 @@
+package {{ base_package }}.repository;
+
+import {{ base_package }}.domain.Widget;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Spring Data repository for {@link Widget}.
+ *
+ * <p>Repositories own persistence. Expose intent-revealing query methods here
+ * rather than leaking JPA details into the service layer.
+ */
+public interface WidgetRepository extends JpaRepository<Widget, Long> {
+}

--- a/src/scaffoldkit/blueprints/springboot-backend/templates/src/main/java/security/SecurityConfig.java.j2
+++ b/src/scaffoldkit/blueprints/springboot-backend/templates/src/main/java/security/SecurityConfig.java.j2
@@ -1,0 +1,29 @@
+package {{ base_package }}.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * Baseline HTTP security for the Spring MVC stack.
+ *
+ * <p>Permits the unauthenticated {@code /health} probe and the actuator health
+ * group, and requires authentication for everything else. Wire your real
+ * {{ auth_method }} authentication (resource server, filters, providers) on top
+ * of this chain.
+ */
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(AbstractHttpConfigurer::disable)
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/health", "/actuator/health").permitAll()
+                .anyRequest().authenticated());
+        return http.build();
+    }
+}

--- a/src/scaffoldkit/blueprints/springboot-backend/templates/src/main/java/security/SecurityConfigReactive.java.j2
+++ b/src/scaffoldkit/blueprints/springboot-backend/templates/src/main/java/security/SecurityConfigReactive.java.j2
@@ -1,0 +1,29 @@
+package {{ base_package }}.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+
+/**
+ * Baseline HTTP security for the WebFlux stack.
+ *
+ * <p>Permits the unauthenticated {@code /health} probe and the actuator health
+ * group, and requires authentication for everything else. Wire your real
+ * {{ auth_method }} authentication on top of this chain.
+ */
+@Configuration
+@EnableWebFluxSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http) {
+        http
+            .csrf(ServerHttpSecurity.CsrfSpec::disable)
+            .authorizeExchange(exchange -> exchange
+                .pathMatchers("/health", "/actuator/health").permitAll()
+                .anyExchange().authenticated());
+        return http.build();
+    }
+}

--- a/src/scaffoldkit/blueprints/springboot-backend/templates/src/main/java/service/HealthService.java.j2
+++ b/src/scaffoldkit/blueprints/springboot-backend/templates/src/main/java/service/HealthService.java.j2
@@ -1,0 +1,28 @@
+package {{ base_package }}.service;
+
+import {{ base_package }}.repository.WidgetRepository;
+import {{ base_package }}.web.dto.HealthResponse;
+import org.springframework.stereotype.Service;
+
+/**
+ * Application service backing the health endpoint.
+ *
+ * <p>Touches the repository so the slice exercises the full web -> service ->
+ * repository wiring rather than returning a hard-coded constant.
+ */
+@Service
+public class HealthService {
+
+    private final WidgetRepository widgetRepository;
+
+    public HealthService(WidgetRepository widgetRepository) {
+        this.widgetRepository = widgetRepository;
+    }
+
+    public HealthResponse check() {
+        // A trivial query proves the persistence layer is wired and reachable.
+        long widgets = widgetRepository.count();
+        String status = widgets >= 0 ? "ok" : "degraded";
+        return new HealthResponse(status, "{{ project_name }}");
+    }
+}

--- a/src/scaffoldkit/blueprints/springboot-backend/templates/src/main/java/web/HealthController.java.j2
+++ b/src/scaffoldkit/blueprints/springboot-backend/templates/src/main/java/web/HealthController.java.j2
@@ -1,0 +1,28 @@
+package {{ base_package }}.web;
+
+import {{ base_package }}.service.HealthService;
+import {{ base_package }}.web.dto.HealthResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Liveness/readiness endpoint.
+ *
+ * <p>Controllers own HTTP only: they delegate to a service and shape the
+ * response. The handler returns a typed DTO directly, which works for both the
+ * Spring MVC and WebFlux stacks.
+ */
+@RestController
+public class HealthController {
+
+    private final HealthService healthService;
+
+    public HealthController(HealthService healthService) {
+        this.healthService = healthService;
+    }
+
+    @GetMapping("/health")
+    public HealthResponse health() {
+        return healthService.check();
+    }
+}

--- a/src/scaffoldkit/blueprints/springboot-backend/templates/src/main/java/web/dto/HealthResponse.java.j2
+++ b/src/scaffoldkit/blueprints/springboot-backend/templates/src/main/java/web/dto/HealthResponse.java.j2
@@ -1,0 +1,10 @@
+package {{ base_package }}.web.dto;
+
+/**
+ * Response payload for the {@code GET /health} endpoint.
+ *
+ * <p>A small immutable DTO so the web layer never leaks domain or persistence
+ * types across the HTTP boundary.
+ */
+public record HealthResponse(String status, String service) {
+}

--- a/src/scaffoldkit/blueprints/springboot-backend/templates/src/main/resources/application.yml.j2
+++ b/src/scaffoldkit/blueprints/springboot-backend/templates/src/main/resources/application.yml.j2
@@ -2,18 +2,28 @@ spring:
   application:
     name: {{ project_name }}
   datasource:
-{% if database == "postgresql" -%}
+{% if database == "postgresql" %}
     url: jdbc:postgresql://localhost:5432/{{ project_name | replace('-', '_') }}
     driver-class-name: org.postgresql.Driver
-{% elif database == "mysql" -%}
+{% elif database == "mysql" %}
     url: jdbc:mysql://localhost:3306/{{ project_name | replace('-', '_') }}
     driver-class-name: com.mysql.cj.jdbc.Driver
-{% else -%}
+{% else %}
     url: jdbc:mariadb://localhost:3306/{{ project_name | replace('-', '_') }}
     driver-class-name: org.mariadb.jdbc.Driver
-{% endif -%}
+{% endif %}
     username: app
     password: change-me
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    open-in-view: false
 
 server:
   port: 8080
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info

--- a/src/scaffoldkit/blueprints/springboot-backend/templates/src/test/java/HealthControllerReactiveSmokeTest.java.j2
+++ b/src/scaffoldkit/blueprints/springboot-backend/templates/src/test/java/HealthControllerReactiveSmokeTest.java.j2
@@ -1,0 +1,34 @@
+package {{ base_package }};
+
+import {{ base_package }}.web.dto.HealthResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+/**
+ * End-to-end smoke test for the WebFlux stack: boots the full application and
+ * hits {@code GET /health} through the reactive test client. Exercises the
+ * web -> service -> repository wiring{% if use_auth %} and confirms the security
+ * chain permits the health probe unauthenticated{% endif %}.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
+class HealthControllerSmokeTest {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @Test
+    void healthEndpointReturnsOk() {
+        webTestClient.get().uri("/health")
+            .exchange()
+            .expectStatus().isOk()
+            .expectBody(HealthResponse.class)
+            .value(body -> {
+                org.assertj.core.api.Assertions.assertThat(body.status()).isEqualTo("ok");
+                org.assertj.core.api.Assertions.assertThat(body.service())
+                    .isEqualTo("{{ project_name }}");
+            });
+    }
+}

--- a/src/scaffoldkit/blueprints/springboot-backend/templates/src/test/java/HealthControllerSmokeTest.java.j2
+++ b/src/scaffoldkit/blueprints/springboot-backend/templates/src/test/java/HealthControllerSmokeTest.java.j2
@@ -1,0 +1,35 @@
+package {{ base_package }};
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import {{ base_package }}.web.dto.HealthResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * End-to-end smoke test: boots the full application on a random port and hits
+ * {@code GET /health} over real HTTP. Exercises the web -> service ->
+ * repository wiring{% if use_auth %} and confirms the security chain permits the
+ * health probe unauthenticated{% endif %}.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class HealthControllerSmokeTest {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    void healthEndpointReturnsOk() {
+        ResponseEntity<HealthResponse> response =
+            restTemplate.getForEntity("/health", HealthResponse.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().status()).isEqualTo("ok");
+        assertThat(response.getBody().service()).isEqualTo("{{ project_name }}");
+    }
+}

--- a/src/scaffoldkit/blueprints/springboot-backend/templates/src/test/resources/application.yml.j2
+++ b/src/scaffoldkit/blueprints/springboot-backend/templates/src/test/resources/application.yml.j2
@@ -1,0 +1,12 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:{{ project_name | replace('-', '_') }}_test;DB_CLOSE_DELAY=-1;MODE=LEGACY
+    driver-class-name: org.h2.Driver
+    username: sa
+    password: ""
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect

--- a/src/scaffoldkit/generator.py
+++ b/src/scaffoldkit/generator.py
@@ -70,6 +70,11 @@ def build_template_context(blueprint: Blueprint, variables: dict[str, Any]) -> d
     ctx["is_api_platform"] = api_style == "api-platform"
     ctx["is_custom_controllers"] = api_style == "custom-controllers"
     ctx["is_fos_rest"] = api_style == "fos-rest"
+    ctx["is_spring_mvc"] = api_style == "spring-mvc"
+    ctx["is_webflux"] = api_style == "webflux"
+    use_auth = bool(variables.get("use_auth"))
+    ctx["is_spring_mvc_auth"] = ctx["is_spring_mvc"] and use_auth
+    ctx["is_webflux_auth"] = ctx["is_webflux"] and use_auth
     use_docker = bool(variables.get("use_docker"))
     use_ci = bool(variables.get("use_ci"))
     ctx["is_nextjs_fullstack_docker"] = ctx["is_nextjs_fullstack"] and use_docker

--- a/tests/test_springboot_backend_starter.py
+++ b/tests/test_springboot_backend_starter.py
@@ -1,0 +1,167 @@
+"""Regression tests for the springboot-backend runnable starter."""
+
+from pathlib import Path
+
+import yaml
+
+from scaffoldkit.blueprint_loader import load_blueprint
+from scaffoldkit.generator import generate
+from scaffoldkit.models import GenerationContext
+
+BLUEPRINTS_DIR = Path(__file__).resolve().parent.parent / "src" / "scaffoldkit" / "blueprints"
+
+# Mirrors the blueprint defaults (build_tool=maven, api_style=spring-mvc, use_auth=true).
+_DEFAULTS = {
+    "project_name": "verify-springboot-backend",
+    "display_name": "Verify springboot-backend",
+    "description": "A Spring Boot API backend",
+    "base_package": "com.example.app",
+    "java_version": "21",
+    "spring_boot_version": "3.4",
+    "build_tool": "maven",
+    "api_style": "spring-mvc",
+    "database": "postgresql",
+    "use_ddd": False,
+    "use_auth": True,
+    "auth_method": "jwt",
+    "use_docker": True,
+    "use_ci": True,
+    "use_kafka": False,
+    "use_redis": False,
+    "test_strategy": "junit-and-testcontainers",
+    "ai_context": True,
+}
+
+_PKG_DIR = "src/main/java/com/example/app"
+_TEST_PKG_DIR = "src/test/java/com/example/app"
+
+
+def _generate(tmp_path: Path, variables: dict) -> Path:
+    bp_path = BLUEPRINTS_DIR / "springboot-backend"
+    bp = load_blueprint(bp_path)
+    output = tmp_path / "output"
+    ctx = GenerationContext(
+        blueprint=bp,
+        blueprint_path=bp_path,
+        variables=variables,
+        target_dir=output,
+    )
+    result = generate(ctx)
+    assert result.success, f"Generation failed: {result.errors}"
+    return output
+
+
+def _assert_nonempty(path: Path) -> str:
+    assert path.exists(), f"expected file missing: {path}"
+    text = path.read_text()
+    assert text.strip(), f"file is empty: {path}"
+    return text
+
+
+class TestSpringbootBackendStarter:
+    def test_vertical_slice_files_exist_and_are_nonempty(self, tmp_path: Path):
+        output = _generate(tmp_path, _DEFAULTS)
+
+        controller = _assert_nonempty(output / _PKG_DIR / "web" / "HealthController.java")
+        dto = _assert_nonempty(output / _PKG_DIR / "web" / "dto" / "HealthResponse.java")
+        service = _assert_nonempty(output / _PKG_DIR / "service" / "HealthService.java")
+        entity = _assert_nonempty(output / _PKG_DIR / "domain" / "Widget.java")
+        repository = _assert_nonempty(output / _PKG_DIR / "repository" / "WidgetRepository.java")
+        smoke = _assert_nonempty(output / _TEST_PKG_DIR / "HealthControllerSmokeTest.java")
+
+        # Controller wires GET /health to the service and returns the DTO.
+        assert '@GetMapping("/health")' in controller
+        assert "HealthService" in controller
+        # DTO is a real record with the expected fields.
+        assert "record HealthResponse" in dto
+        # Service touches the repository so the slice is genuinely wired.
+        assert "WidgetRepository" in service
+        # Entity is a mapped JPA entity, repository is Spring Data.
+        assert "@Entity" in entity
+        assert "JpaRepository<Widget, Long>" in repository
+        # Smoke test boots the app and hits /health.
+        assert "@SpringBootTest" in smoke
+        assert "/health" in smoke
+
+    def test_rendered_application_yml_is_valid_yaml(self, tmp_path: Path):
+        # Regression: the {%- -%} whitespace control mangled the datasource
+        # indentation, producing YAML that failed to parse.
+        output = _generate(tmp_path, _DEFAULTS)
+
+        main_yml = output / "src" / "main" / "resources" / "application.yml"
+        test_yml = output / "src" / "test" / "resources" / "application.yml"
+
+        main_data = yaml.safe_load(_assert_nonempty(main_yml))
+        assert main_data["spring"]["application"]["name"] == "verify-springboot-backend"
+        assert "jdbc:postgresql" in main_data["spring"]["datasource"]["url"]
+        assert main_data["spring"]["datasource"]["driver-class-name"] == "org.postgresql.Driver"
+
+        test_data = yaml.safe_load(_assert_nonempty(test_yml))
+        assert "jdbc:h2:mem" in test_data["spring"]["datasource"]["url"]
+
+    def test_java_sources_have_balanced_braces_and_matching_package(self, tmp_path: Path):
+        output = _generate(tmp_path, _DEFAULTS)
+
+        for java_file in sorted(output.rglob("*.java")):
+            text = java_file.read_text()
+            assert text.count("{") == text.count("}"), f"unbalanced braces: {java_file}"
+            assert text.count("(") == text.count(")"), f"unbalanced parens: {java_file}"
+
+            first_pkg_line = next(
+                line for line in text.splitlines() if line.startswith("package ")
+            )
+            declared = first_pkg_line[len("package "):].rstrip(";").strip()
+
+            parts = java_file.relative_to(output).parts
+            java_idx = parts.index("java")
+            expected = ".".join(parts[java_idx + 1 : -1])
+            assert declared == expected, (
+                f"package mismatch in {java_file}: declared {declared} expected {expected}"
+            )
+
+    def test_security_config_permits_health_when_auth_enabled(self, tmp_path: Path):
+        output = _generate(tmp_path, _DEFAULTS)
+        security = output / _PKG_DIR / "security" / "SecurityConfig.java"
+        text = _assert_nonempty(security)
+        assert "SecurityFilterChain" in text
+        assert '"/health"' in text
+        assert "permitAll" in text
+
+    def test_no_security_config_when_auth_disabled(self, tmp_path: Path):
+        output = _generate(tmp_path, {**_DEFAULTS, "use_auth": False})
+        security = output / _PKG_DIR / "security" / "SecurityConfig.java"
+        assert not security.exists()
+
+    def test_maven_wrapper_generated_for_maven_only(self, tmp_path: Path):
+        maven_out = _generate(tmp_path / "maven", _DEFAULTS)
+        assert (maven_out / "mvnw").exists()
+        assert (maven_out / "mvnw.cmd").exists()
+        props = maven_out / ".mvn" / "wrapper" / "maven-wrapper.properties"
+        props_text = _assert_nonempty(props)
+        assert "distributionUrl=" in props_text
+
+        gradle_out = _generate(
+            tmp_path / "gradle", {**_DEFAULTS, "build_tool": "gradle"}
+        )
+        assert not (gradle_out / "mvnw").exists()
+        assert not (gradle_out / ".mvn" / "wrapper" / "maven-wrapper.properties").exists()
+
+    def test_webflux_emits_reactive_slice(self, tmp_path: Path):
+        output = _generate(tmp_path, {**_DEFAULTS, "api_style": "webflux"})
+
+        # Single smoke test target, rendered from the reactive variant.
+        smoke = _assert_nonempty(output / _TEST_PKG_DIR / "HealthControllerSmokeTest.java")
+        assert "WebTestClient" in smoke
+
+        security = _assert_nonempty(output / _PKG_DIR / "security" / "SecurityConfig.java")
+        assert "EnableWebFluxSecurity" in security
+        assert "SecurityWebFilterChain" in security
+
+    def test_pom_renders_well_formed_xml(self, tmp_path: Path):
+        import xml.dom.minidom as minidom
+
+        output = _generate(tmp_path, _DEFAULTS)
+        pom_text = _assert_nonempty(output / "pom.xml")
+        minidom.parseString(pom_text)
+        assert "<artifactId>h2</artifactId>" in pom_text
+        assert "spring-security-test" in pom_text

--- a/tests/test_springboot_backend_starter.py
+++ b/tests/test_springboot_backend_starter.py
@@ -107,10 +107,8 @@ class TestSpringbootBackendStarter:
             assert text.count("{") == text.count("}"), f"unbalanced braces: {java_file}"
             assert text.count("(") == text.count(")"), f"unbalanced parens: {java_file}"
 
-            first_pkg_line = next(
-                line for line in text.splitlines() if line.startswith("package ")
-            )
-            declared = first_pkg_line[len("package "):].rstrip(";").strip()
+            first_pkg_line = next(line for line in text.splitlines() if line.startswith("package "))
+            declared = first_pkg_line[len("package ") :].rstrip(";").strip()
 
             parts = java_file.relative_to(output).parts
             java_idx = parts.index("java")
@@ -140,9 +138,7 @@ class TestSpringbootBackendStarter:
         props_text = _assert_nonempty(props)
         assert "distributionUrl=" in props_text
 
-        gradle_out = _generate(
-            tmp_path / "gradle", {**_DEFAULTS, "build_tool": "gradle"}
-        )
+        gradle_out = _generate(tmp_path / "gradle", {**_DEFAULTS, "build_tool": "gradle"})
         assert not (gradle_out / "mvnw").exists()
         assert not (gradle_out / ".mvn" / "wrapper" / "maven-wrapper.properties").exists()
 


### PR DESCRIPTION
## What
The `springboot-backend` blueprint emitted a hollow `@SpringBootApplication` stub with empty business packages; `application.yml.j2` was mangled by a Jinja whitespace control producing invalid YAML; no Maven wrapper.

## Fix
Emit a vertical slice under the base package (Controller, DTO, Service, Entity, Repository, SecurityConfig when use_auth) plus a `/health` smoke test; fix the `application.yml.j2` indentation; add the Maven wrapper for `build_tool=maven`.

## Verification
No JDK in the env (cannot compile), so verified via render + YAML parse of the generated `application.yml` + Java structural checks (balanced braces, package decls match paths) + scaffoldkit pytest + `uv build`. Rigorous review subagent: SHIP, 0 must-fix. Note: planforge has no Java selector path, so this blueprint is reachable only via scaffoldkit directly.

Refs: PHASE3_LANE_A_REPORT_2026-06-02.md