### PR TITLE
feat(symfony-nextjs): emit runnable Symfony + Next.js monorepo starter

### DIFF
--- a/src/scaffoldkit/blueprints/symfony-nextjs/blueprint.yaml
+++ b/src/scaffoldkit/blueprints/symfony-nextjs/blueprint.yaml
@@ -164,6 +164,63 @@ templates:
   - source: apps/api/composer.json.j2
     target: apps/api/composer.json
 
+  - source: apps/api/public/index.php.j2
+    target: apps/api/public/index.php
+
+  - source: apps/api/bin/console.j2
+    target: apps/api/bin/console
+
+  - source: apps/api/src/Kernel.php.j2
+    target: apps/api/src/Kernel.php
+
+  - source: apps/api/src/Controller/HealthController.php.j2
+    target: apps/api/src/Controller/HealthController.php
+
+  - source: apps/api/config/bundles.php.j2
+    target: apps/api/config/bundles.php
+
+  - source: apps/api/config/routes.yaml.j2
+    target: apps/api/config/routes.yaml
+
+  - source: apps/api/config/services.yaml.j2
+    target: apps/api/config/services.yaml
+
+  - source: apps/api/config/packages/framework.yaml.j2
+    target: apps/api/config/packages/framework.yaml
+
+  - source: apps/api/.env.example.j2
+    target: apps/api/.env.example
+
+  - source: apps/api/phpunit.dist.xml.j2
+    target: apps/api/phpunit.dist.xml
+
+  - source: apps/api/tests/Unit/Controller/HealthControllerTest.php.j2
+    target: apps/api/tests/Unit/Controller/HealthControllerTest.php
+
+  - source: apps/web/src/app/layout.tsx.j2
+    target: apps/web/src/app/layout.tsx
+
+  - source: apps/web/src/app/page.tsx.j2
+    target: apps/web/src/app/page.tsx
+
+  - source: apps/web/src/services/health.ts.j2
+    target: apps/web/src/services/health.ts
+
+  - source: apps/web/src/services/health.test.ts.j2
+    target: apps/web/src/services/health.test.ts
+
+  - source: apps/web/next.config.mjs.j2
+    target: apps/web/next.config.mjs
+
+  - source: apps/web/tsconfig.json.j2
+    target: apps/web/tsconfig.json
+
+  - source: apps/web/.env.example.j2
+    target: apps/web/.env.example
+
+  - source: packages/shared-types/src/index.ts.j2
+    target: packages/shared-types/src/index.ts
+
   - source: packages/shared-types/package.json.j2
     target: packages/shared-types/package.json
 

--- a/src/scaffoldkit/blueprints/symfony-nextjs/templates/apps/api/.env.example.j2
+++ b/src/scaffoldkit/blueprints/symfony-nextjs/templates/apps/api/.env.example.j2
@@ -1,0 +1,12 @@
+APP_ENV=dev
+APP_SECRET=change-me-to-a-long-random-string
+APP_DEBUG=1
+
+{% if database == "postgresql" -%}
+DATABASE_URL="postgresql://app:password@127.0.0.1:5432/{{ project_name }}?serverVersion=15&charset=utf8"
+{% else -%}
+DATABASE_URL="mysql://app:password@127.0.0.1:3306/{{ project_name }}?serverVersion=8.0&charset=utf8mb4"
+{% endif -%}
+
+# Origin allowed to call this API from the browser (the Next.js frontend).
+CORS_ALLOW_ORIGIN="http://localhost:3000"

--- a/src/scaffoldkit/blueprints/symfony-nextjs/templates/apps/api/bin/console.j2
+++ b/src/scaffoldkit/blueprints/symfony-nextjs/templates/apps/api/bin/console.j2
@@ -1,0 +1,13 @@
+#!/usr/bin/env php
+<?php
+
+use App\Kernel;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+
+require_once dirname(__DIR__) . '/vendor/autoload_runtime.php';
+
+return function (array $context) {
+    $kernel = new Kernel($context['APP_ENV'], (bool) $context['APP_DEBUG']);
+
+    return new Application($kernel);
+};

--- a/src/scaffoldkit/blueprints/symfony-nextjs/templates/apps/api/composer.json.j2
+++ b/src/scaffoldkit/blueprints/symfony-nextjs/templates/apps/api/composer.json.j2
@@ -1,6 +1,7 @@
 {
   "name": "{{ project_name }}/api",
   "type": "project",
+  "license": "proprietary",
   "description": "{{ description }}",
   "require": {
     "php": "^{{ php_version }}",
@@ -21,12 +22,46 @@
     "symfony/security-bundle": "^7.2"{% endif %}{% if api_style == "api-platform" %},
     "api-platform/symfony": "^4.1"{% endif %}{% if use_rabbitmq %},
     "symfony/messenger": "^7.2",
-    "symfony/amqp-messenger": "^7.2"{% endif %}
+    "symfony/amqp-messenger": "^7.2"{% endif %}{% if use_redis %},
+    "symfony/cache": "^7.2"{% endif %}
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^11.5",
+    "symfony/phpunit-bridge": "^7.2"
   },
   "autoload": {
     "psr-4": {
-      "App\\\\": "src/"
+      "App\\": "src/"
     }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "App\\Tests\\": "tests/"
+    }
+  },
+  "scripts": {
+    "auto-scripts": {
+      "cache:clear": "symfony-cmd"
+    },
+    "post-install-cmd": [
+      "@auto-scripts"
+    ],
+    "post-update-cmd": [
+      "@auto-scripts"
+    ],
+    "lint": [
+      "php -l src/Kernel.php",
+      "php -l public/index.php"
+    ],
+    "test": "phpunit"
+  },
+  "config": {
+    "allow-plugins": {
+      "php-http/discovery": true,
+      "symfony/flex": true,
+      "symfony/runtime": true
+    },
+    "sort-packages": true
   },
   "extra": {
     "symfony": {

--- a/src/scaffoldkit/blueprints/symfony-nextjs/templates/apps/api/config/bundles.php.j2
+++ b/src/scaffoldkit/blueprints/symfony-nextjs/templates/apps/api/config/bundles.php.j2
@@ -1,0 +1,13 @@
+<?php
+
+return [
+    Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => ['all' => true],
+    Doctrine\Bundle\DoctrineBundle\DoctrineBundle::class => ['all' => true],
+    Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle::class => ['all' => true],
+{% if use_auth -%}
+    Symfony\Bundle\SecurityBundle\SecurityBundle::class => ['all' => true],
+{% endif -%}
+{% if api_style == "api-platform" -%}
+    ApiPlatform\Symfony\Bundle\ApiPlatformBundle::class => ['all' => true],
+{% endif -%}
+];

--- a/src/scaffoldkit/blueprints/symfony-nextjs/templates/apps/api/config/packages/framework.yaml.j2
+++ b/src/scaffoldkit/blueprints/symfony-nextjs/templates/apps/api/config/packages/framework.yaml.j2
@@ -1,0 +1,10 @@
+framework:
+  secret: '%env(APP_SECRET)%'
+  http_method_override: false
+  handle_all_throwables: true
+
+when@test:
+  framework:
+    test: true
+    session:
+      storage_factory_id: session.storage.factory.mock_file

--- a/src/scaffoldkit/blueprints/symfony-nextjs/templates/apps/api/config/routes.yaml.j2
+++ b/src/scaffoldkit/blueprints/symfony-nextjs/templates/apps/api/config/routes.yaml.j2
@@ -1,0 +1,5 @@
+controllers:
+  resource:
+    path: ../src/Controller/
+    namespace: App\Controller
+  type: attribute

--- a/src/scaffoldkit/blueprints/symfony-nextjs/templates/apps/api/config/services.yaml.j2
+++ b/src/scaffoldkit/blueprints/symfony-nextjs/templates/apps/api/config/services.yaml.j2
@@ -1,0 +1,13 @@
+parameters:
+
+services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+
+  App\:
+    resource: '../src/'
+    exclude:
+      - '../src/DependencyInjection/'
+      - '../src/Entity/'
+      - '../src/Kernel.php'

--- a/src/scaffoldkit/blueprints/symfony-nextjs/templates/apps/api/phpunit.dist.xml.j2
+++ b/src/scaffoldkit/blueprints/symfony-nextjs/templates/apps/api/phpunit.dist.xml.j2
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheDirectory=".phpunit.cache">
+    <php>
+        <ini name="display_errors" value="1" />
+        <ini name="error_reporting" value="-1" />
+        <server name="APP_ENV" value="test" force="true" />
+        <server name="SHELL_VERBOSITY" value="-1" />
+    </php>
+    <testsuites>
+        <testsuite name="{{ project_name }} API Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/src/scaffoldkit/blueprints/symfony-nextjs/templates/apps/api/public/index.php.j2
+++ b/src/scaffoldkit/blueprints/symfony-nextjs/templates/apps/api/public/index.php.j2
@@ -1,0 +1,9 @@
+<?php
+
+use App\Kernel;
+
+require_once dirname(__DIR__) . '/vendor/autoload_runtime.php';
+
+return function (array $context) {
+    return new Kernel($context['APP_ENV'], (bool) $context['APP_DEBUG']);
+};

--- a/src/scaffoldkit/blueprints/symfony-nextjs/templates/apps/api/src/Controller/HealthController.php.j2
+++ b/src/scaffoldkit/blueprints/symfony-nextjs/templates/apps/api/src/Controller/HealthController.php.j2
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Controller;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class HealthController
+{
+    #[Route('/health', name: 'app_health', methods: ['GET'])]
+    public function __invoke(): JsonResponse
+    {
+        return new JsonResponse([
+            'status' => 'ok',
+            'service' => '{{ project_name }}',
+        ]);
+    }
+}

--- a/src/scaffoldkit/blueprints/symfony-nextjs/templates/apps/api/src/Kernel.php.j2
+++ b/src/scaffoldkit/blueprints/symfony-nextjs/templates/apps/api/src/Kernel.php.j2
@@ -1,0 +1,11 @@
+<?php
+
+namespace App;
+
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\HttpKernel\Kernel as BaseKernel;
+
+final class Kernel extends BaseKernel
+{
+    use MicroKernelTrait;
+}

--- a/src/scaffoldkit/blueprints/symfony-nextjs/templates/apps/api/tests/Unit/Controller/HealthControllerTest.php.j2
+++ b/src/scaffoldkit/blueprints/symfony-nextjs/templates/apps/api/tests/Unit/Controller/HealthControllerTest.php.j2
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Controller;
+
+use App\Controller\HealthController;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+final class HealthControllerTest extends TestCase
+{
+    public function testHealthEndpointReturnsOkStatus(): void
+    {
+        $response = (new HealthController())();
+
+        self::assertInstanceOf(JsonResponse::class, $response);
+        self::assertSame(200, $response->getStatusCode());
+
+        $payload = json_decode((string) $response->getContent(), true);
+        self::assertSame('ok', $payload['status']);
+        self::assertSame('{{ project_name }}', $payload['service']);
+    }
+}

--- a/src/scaffoldkit/blueprints/symfony-nextjs/templates/apps/web/.env.example.j2
+++ b/src/scaffoldkit/blueprints/symfony-nextjs/templates/apps/web/.env.example.j2
@@ -1,0 +1,2 @@
+# Base URL of the Symfony API the frontend talks to (browser + SSR).
+NEXT_PUBLIC_API_URL=http://localhost:8000

--- a/src/scaffoldkit/blueprints/symfony-nextjs/templates/apps/web/next.config.mjs.j2
+++ b/src/scaffoldkit/blueprints/symfony-nextjs/templates/apps/web/next.config.mjs.j2
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  // The shared-types package is consumed as source from the monorepo workspace.
+  transpilePackages: ["@{{ project_name }}/shared-types"],
+};
+
+export default nextConfig;

--- a/src/scaffoldkit/blueprints/symfony-nextjs/templates/apps/web/package.json.j2
+++ b/src/scaffoldkit/blueprints/symfony-nextjs/templates/apps/web/package.json.j2
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest run"
   },
   "dependencies": {
     "next": "^15.2.4",
@@ -24,6 +25,7 @@
     "@types/react-dom": "^19.0.4",
     "eslint": "^9.22.0",
     "eslint-config-next": "^15.2.4",
-    "typescript": "^5.8.2"
+    "typescript": "^5.8.2",
+    "vitest": "^3.0.5"
   }
 }

--- a/src/scaffoldkit/blueprints/symfony-nextjs/templates/apps/web/src/app/layout.tsx.j2
+++ b/src/scaffoldkit/blueprints/symfony-nextjs/templates/apps/web/src/app/layout.tsx.j2
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = {
+  title: "{{ display_name }}",
+  description: "{{ description }}",
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/src/scaffoldkit/blueprints/symfony-nextjs/templates/apps/web/src/app/page.tsx.j2
+++ b/src/scaffoldkit/blueprints/symfony-nextjs/templates/apps/web/src/app/page.tsx.j2
@@ -1,0 +1,29 @@
+import { getApiHealth } from "../services/health";
+
+// Render on every request so the API health probe reflects live status.
+export const dynamic = "force-dynamic";
+
+const pageStyle = { fontFamily: "system-ui, sans-serif", padding: "2rem" };
+
+export default async function HomePage() {
+  const health = await getApiHealth();
+
+  return (
+    <main style={pageStyle}>
+      <h1>{{ display_name }}</h1>
+      <p>{{ description }}</p>
+      <section>
+        <h2>API status</h2>
+{% raw %}        {health ? (
+          <p data-testid="api-status">
+            {health.service}: <strong>{health.status}</strong>
+          </p>
+        ) : (
+          <p data-testid="api-status">
+            API unreachable. Start the Symfony backend and reload.
+          </p>
+        )}
+{% endraw %}      </section>
+    </main>
+  );
+}

--- a/src/scaffoldkit/blueprints/symfony-nextjs/templates/apps/web/src/services/health.test.ts.j2
+++ b/src/scaffoldkit/blueprints/symfony-nextjs/templates/apps/web/src/services/health.test.ts.j2
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getApiHealth } from "./health";
+
+describe("getApiHealth", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns the parsed health payload on a successful response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ status: "ok", service: "{{ project_name }}" }),
+      }),
+    );
+
+    const result = await getApiHealth();
+
+    expect(result).toEqual({ status: "ok", service: "{{ project_name }}" });
+  });
+
+  it("returns null when the backend is unreachable", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("ECONNREFUSED")),
+    );
+
+    expect(await getApiHealth()).toBeNull();
+  });
+});

--- a/src/scaffoldkit/blueprints/symfony-nextjs/templates/apps/web/src/services/health.ts.j2
+++ b/src/scaffoldkit/blueprints/symfony-nextjs/templates/apps/web/src/services/health.ts.j2
@@ -1,0 +1,22 @@
+import type { HealthStatus } from "@{{ project_name }}/shared-types";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+
+/**
+ * Fetch the API health probe. Returns null when the backend is unreachable so
+ * the page can render a graceful fallback instead of throwing during SSR.
+ */
+export async function getApiHealth(): Promise<HealthStatus | null> {
+  try {
+    const res = await fetch(`${API_BASE_URL}/health`, {
+      headers: { Accept: "application/json" },
+      cache: "no-store",
+    });
+    if (!res.ok) {
+      return null;
+    }
+    return (await res.json()) as HealthStatus;
+  } catch {
+    return null;
+  }
+}

--- a/src/scaffoldkit/blueprints/symfony-nextjs/templates/apps/web/tsconfig.json.j2
+++ b/src/scaffoldkit/blueprints/symfony-nextjs/templates/apps/web/tsconfig.json.j2
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "baseUrl": ".",
+    "paths": {
+      "@{{ project_name }}/shared-types": ["../../packages/shared-types/src/index.ts"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/src/scaffoldkit/blueprints/symfony-nextjs/templates/packages/shared-types/package.json.j2
+++ b/src/scaffoldkit/blueprints/symfony-nextjs/templates/packages/shared-types/package.json.j2
@@ -3,6 +3,11 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "scripts": {
     "generate": "openapi-typescript http://localhost:8000/api/docs.json -o src/index.ts"
   },

--- a/src/scaffoldkit/blueprints/symfony-nextjs/templates/packages/shared-types/src/index.ts.j2
+++ b/src/scaffoldkit/blueprints/symfony-nextjs/templates/packages/shared-types/src/index.ts.j2
@@ -1,0 +1,15 @@
+/**
+ * Types shared between the Symfony API and the Next.js web app.
+ *
+ * The Symfony side documents the matching shape in
+ * `apps/api/src/Controller/HealthController.php` (GET /health). Keep both in
+ * sync, or regenerate from the OpenAPI document via `pnpm generate:types`.
+ */
+
+/** Response body of the API health probe (GET /health). */
+export interface HealthStatus {
+  /** Liveness flag, "ok" when the API is healthy. */
+  status: "ok";
+  /** Service identifier (the project slug). */
+  service: string;
+}

--- a/tests/test_symfony_nextjs_starter.py
+++ b/tests/test_symfony_nextjs_starter.py
@@ -1,0 +1,122 @@
+"""Tests for the symfony-nextjs blueprint runnable starter."""
+
+import json
+from pathlib import Path
+
+from scaffoldkit.blueprint_loader import load_blueprint
+from scaffoldkit.generator import generate
+from scaffoldkit.models import GenerationContext
+
+BLUEPRINTS_DIR = Path(__file__).resolve().parent.parent / "src" / "scaffoldkit" / "blueprints"
+
+_DEFAULTS = {
+    "project_name": "verify-symfony-nextjs",
+    "display_name": "Verify symfony-nextjs",
+    "description": "A fullstack application with Symfony API and Next.js frontend",
+    "php_version": "8.3",
+    "node_version": "22",
+    "api_style": "api-platform",
+    "database": "postgresql",
+    "use_ddd": False,
+    "use_auth": True,
+    "auth_method": "jwt",
+    "styling": "tailwind",
+    "ui_library": "shadcn-ui",
+    "use_docker": True,
+    "use_ci": True,
+    "use_rabbitmq": False,
+    "use_redis": False,
+    "test_strategy": "unit-and-integration",
+    "design_style": "minimal-clean",
+    "ai_context": True,
+}
+
+
+def _generate(tmp_path: Path, variables: dict) -> Path:
+    bp_path = BLUEPRINTS_DIR / "symfony-nextjs"
+    bp = load_blueprint(bp_path)
+    output = tmp_path / "output"
+    ctx = GenerationContext(
+        blueprint=bp,
+        blueprint_path=bp_path,
+        variables=variables,
+        target_dir=output,
+    )
+    result = generate(ctx)
+    assert result.success, f"Generation failed: {result.errors}"
+    return output
+
+
+class TestSymfonyNextjsStarter:
+    def test_emits_runnable_api_source(self, tmp_path: Path):
+        output = _generate(tmp_path, _DEFAULTS)
+
+        api_files = [
+            output / "apps" / "api" / "public" / "index.php",
+            output / "apps" / "api" / "bin" / "console",
+            output / "apps" / "api" / "src" / "Kernel.php",
+            output / "apps" / "api" / "src" / "Controller" / "HealthController.php",
+            output / "apps" / "api" / "config" / "bundles.php",
+            output / "apps" / "api" / "config" / "routes.yaml",
+            output / "apps" / "api" / "config" / "services.yaml",
+            output / "apps" / "api" / "config" / "packages" / "framework.yaml",
+            output / "apps" / "api" / ".env.example",
+            output / "apps" / "api" / "phpunit.dist.xml",
+            output / "apps" / "api" / "tests" / "Unit" / "Controller" / "HealthControllerTest.php",
+        ]
+        for f in api_files:
+            assert f.exists(), f"missing {f}"
+            assert f.read_text().strip(), f"empty {f}"
+
+        controller = (
+            output / "apps" / "api" / "src" / "Controller" / "HealthController.php"
+        ).read_text()
+        assert "#[Route('/health'" in controller
+        assert "'status' => 'ok'" in controller
+
+    def test_emits_runnable_web_source(self, tmp_path: Path):
+        output = _generate(tmp_path, _DEFAULTS)
+
+        web_files = [
+            output / "apps" / "web" / "src" / "app" / "layout.tsx",
+            output / "apps" / "web" / "src" / "app" / "page.tsx",
+            output / "apps" / "web" / "src" / "services" / "health.ts",
+            output / "apps" / "web" / "src" / "services" / "health.test.ts",
+            output / "apps" / "web" / "next.config.mjs",
+            output / "apps" / "web" / "tsconfig.json",
+            output / "apps" / "web" / ".env.example",
+            output / "packages" / "shared-types" / "src" / "index.ts",
+        ]
+        for f in web_files:
+            assert f.exists(), f"missing {f}"
+            assert f.read_text().strip(), f"empty {f}"
+
+        page = (output / "apps" / "web" / "src" / "app" / "page.tsx").read_text()
+        assert "Verify symfony-nextjs" in page
+        assert "getApiHealth" in page
+
+        shared = (output / "packages" / "shared-types" / "src" / "index.ts").read_text()
+        assert "interface HealthStatus" in shared
+
+    def test_composer_psr4_and_runtime_plugin_are_correct(self, tmp_path: Path):
+        output = _generate(tmp_path, _DEFAULTS)
+        composer = json.loads((output / "apps" / "api" / "composer.json").read_text())
+
+        # PSR-4 prefix must be a single namespace separator. Regression: the
+        # template double-escaped it to "App\\\\" which Composer reads as a
+        # double separator, so autoload resolves nothing (ClassNotFoundError).
+        assert composer["autoload"]["psr-4"] == {"App\\": "src/"}
+        assert composer["autoload-dev"]["psr-4"] == {"App\\Tests\\": "tests/"}
+
+        # symfony/runtime ships a Composer plugin generating
+        # vendor/autoload_runtime.php (required by public/index.php + bin/console);
+        # it must be allow-listed or Composer 2.2+ blocks it.
+        assert composer["config"]["allow-plugins"].get("symfony/runtime") is True
+        assert "phpunit/phpunit" in composer["require-dev"]
+
+    def test_web_package_has_vitest_smoke_test(self, tmp_path: Path):
+        output = _generate(tmp_path, _DEFAULTS)
+        pkg = json.loads((output / "apps" / "web" / "package.json").read_text())
+
+        assert pkg["scripts"]["test"] == "vitest run"
+        assert "vitest" in pkg["devDependencies"]


### PR DESCRIPTION
## What
The `symfony-nextjs` monorepo blueprint emitted 0 source (docs/config/docker only).

## Fix
Emit `apps/api` (Symfony kernel + HealthController + a composer.json with single-separator PSR-4 and `symfony/runtime` allow-listed, per the PR #52 lesson) + `apps/web` (Next.js app-router) + `packages/shared-types` + `.env.example` files, plus smoke tests.

## Verification
`apps/web` `next build` emits an authored route (not just /404); PHP side `php -l` clean + `composer validate` valid (full install needs PHP 8.2+, not runnable on the 8.1 host); scaffoldkit pytest + `uv build` green. Rigorous review subagent: SHIP, 0 must-fix.

Refs: PHASE3_LANE_A_REPORT_2026-06-02.md