### PR TITLE
release: scaffoldkit v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-06-02
+
+### Added
+
+- Runnable starter code for the remaining blueprints, so a generated project opens with a working app and a green smoke test instead of an empty `src/`: `express-api` ([#53](https://github.com/LanNguyenSi/scaffoldkit/pull/53)), `nextjs-frontend` ([#54](https://github.com/LanNguyenSi/scaffoldkit/pull/54)), `nextjs-fullstack` ([#55](https://github.com/LanNguyenSi/scaffoldkit/pull/55)), `static-site` (Astro) ([#56](https://github.com/LanNguyenSi/scaffoldkit/pull/56)), `django-drf` ([#57](https://github.com/LanNguyenSi/scaffoldkit/pull/57)), `springboot-backend` ([#59](https://github.com/LanNguyenSi/scaffoldkit/pull/59)), and the `symfony-nextjs` monorepo ([#60](https://github.com/LanNguyenSi/scaffoldkit/pull/60))
+- `express` and `django-rest` runnable starters for the generic `rest-api` blueprint, alongside the existing FastAPI path ([#58](https://github.com/LanNguyenSi/scaffoldkit/pull/58))
+
+### Fixed
+
+- `symfony-backend`: corrected a double-escaped PSR-4 prefix and allow-listed the `symfony/runtime` Composer plugin so a generated project's autoload and bootstrap work, plus a runnable HealthController smoke test ([#52](https://github.com/LanNguyenSi/scaffoldkit/pull/52))
+- Wheel build: excluded `blueprints/` from the wheel `packages` selection so they ship only via `force-include`, fixing a latent Hatchling duplicate-path collision ([#52](https://github.com/LanNguyenSi/scaffoldkit/pull/52))
+- `springboot-backend`: fixed `application.yml` whitespace corruption and added the Maven wrapper ([#59](https://github.com/LanNguyenSi/scaffoldkit/pull/59))
+- `nextjs-frontend`: bumped `next` off the vulnerable 15.2.4 to a patched 15.x release ([#54](https://github.com/LanNguyenSi/scaffoldkit/pull/54))
+
 ### Removed
 
-- Removed the `reference-php-app` blueprint, an app-less ops/CI/security shell whose `project/` directory was only a placeholder mount. The runnable `symfony-backend` and `symfony-nextjs` blueprints cover real PHP/Symfony app and monorepo scaffolds.
+- Removed the `reference-php-app` blueprint, an app-less ops/CI/security shell whose `project/` directory was only a placeholder mount. The runnable `symfony-backend` and `symfony-nextjs` blueprints cover real PHP/Symfony app and monorepo scaffolds ([#61](https://github.com/LanNguyenSi/scaffoldkit/pull/61))
 
 ## [0.3.0] - 2026-06-01
 
@@ -105,7 +119,8 @@ A `Dockerfile` and `docker-compose.yml` are shipped for the Docker path.
 - Single-user local execution; no concurrency guards.
 - Blueprint variables are flat (no nested objects).
 
-[Unreleased]: https://github.com/LanNguyenSi/scaffoldkit/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/LanNguyenSi/scaffoldkit/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/LanNguyenSi/scaffoldkit/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/LanNguyenSi/scaffoldkit/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/LanNguyenSi/scaffoldkit/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/LanNguyenSi/scaffoldkit/releases/tag/v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scaffoldkit"
-version = "0.3.0"
+version = "0.4.0"
 description = "AI-aided project scaffolding tool with declarative blueprints"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/scaffoldkit/__init__.py
+++ b/src/scaffoldkit/__init__.py
@@ -1,3 +1,3 @@
 """ScaffoldKit - AI-aided project scaffolding tool."""
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"


### PR DESCRIPTION
## Release scaffoldkit v0.4.0

Completes the Phase-3 blueprint-buildability work.

### Highlights
- Runnable starter code for every remaining blueprint (express-api, nextjs-frontend, nextjs-fullstack, static-site/Astro, django-drf, rest-api express+django, springboot, symfony-nextjs), so a generated project opens with a working app and smoke test, not an empty `src/`.
- `symfony-backend` PSR-4 + `symfony/runtime` fix + smoke test.
- Wheel-build force-include collision fix.
- `reference-php-app` blueprint removed (12 blueprints remain).

### Mechanics
- Version 0.3.0 to 0.4.0 (pyproject + `__init__`).
- CHANGELOG `[Unreleased]` to `[0.4.0]` + footer compare link.
- 323 tests pass; the `[0.4.0]` section extracts cleanly for release.yml.

The `v0.4.0` tag is pushed after merge to trigger the release workflow.

Refs: PHASE3_LANE_A_REPORT_2026-06-02.md