### PR TITLE
fix(blueprints): bump next off CVE-2025-66478 in symfony-nextjs, saas-dashboard, static-site

### DIFF
--- a/src/scaffoldkit/blueprints/saas-dashboard/templates/apps/web/nextjs/package.json.j2
+++ b/src/scaffoldkit/blueprints/saas-dashboard/templates/apps/web/nextjs/package.json.j2
@@ -9,7 +9,7 @@
     "test": "node --test"
   },
   "dependencies": {
-    "next": "^15.2.4",
+    "next": "15.5.19",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/src/scaffoldkit/blueprints/static-site/templates/package.json.j2
+++ b/src/scaffoldkit/blueprints/static-site/templates/package.json.j2
@@ -35,7 +35,7 @@
     "astro": "^5.5.2"
 {% endif %}
 {% elif framework == "nextjs-static" %}
-    "next": "^15.2.4",
+    "next": "15.5.19",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
 {% else %}

--- a/src/scaffoldkit/blueprints/symfony-nextjs/templates/apps/web/package.json.j2
+++ b/src/scaffoldkit/blueprints/symfony-nextjs/templates/apps/web/package.json.j2
@@ -10,7 +10,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "next": "^15.2.4",
+    "next": "15.5.19",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"{% if styling == "tailwind" %},
     "tailwindcss": "^3.4.17"{% endif %}{% if ui_library == "radix-ui" %},
@@ -24,7 +24,7 @@
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
     "eslint": "^9.22.0",
-    "eslint-config-next": "^15.2.4",
+    "eslint-config-next": "15.5.19",
     "typescript": "^5.8.2",
     "vitest": "^3.0.5"
   }

--- a/tests/test_blueprint_contract_audit.py
+++ b/tests/test_blueprint_contract_audit.py
@@ -146,3 +146,13 @@ class TestBlueprintContractAudit:
     def test_known_unused_variable_gaps_snapshot(self):
         """Track variables that are declared in blueprints but not referenced anywhere."""
         assert _audit_unused_variable_gaps() == _KNOWN_UNUSED_VARIABLES
+
+    def test_no_blueprint_pins_next_to_known_cve_version(self):
+        """No package.json template may pin next to 15.2.4 (CVE-2025-66478)."""
+        offenders = []
+        for pkg in BLUEPRINTS_DIR.glob("**/package.json.j2"):
+            for lineno, line in enumerate(pkg.read_text().splitlines(), start=1):
+                if '"next"' in line and "15.2.4" in line:
+                    rel = pkg.relative_to(BLUEPRINTS_DIR)
+                    offenders.append(f"{rel}:{lineno}")
+        assert offenders == [], f"next pinned to CVE-2025-66478 version: {offenders}"


### PR DESCRIPTION
## What

Three Next.js blueprints still shipped `next: "^15.2.4"`, whose floor is vulnerable to CVE-2025-66478 (RSC/App Router; patched at >=15.5.7 in the 15.5 line). This bumps them to 15.5.19, matching `nextjs-fullstack` and `nextjs-frontend`.

## Changes

- `symfony-nextjs/apps/web/package.json.j2`: `next` and `eslint-config-next` -> 15.5.19.
- `saas-dashboard/apps/web/nextjs/package.json.j2`: `next` -> 15.5.19.
- `static-site/package.json.j2` (nextjs-static branch): `next` -> 15.5.19.
- Source-level guard in the blueprint contract audit so no `package.json.j2` can reintroduce the 15.2.4 pin.

`eslint-config-next` is only pinned by `symfony-nextjs` of the three; the other two do not declare it.

## Verification

- Each blueprint's Next.js web app renders valid JSON with `next=15.5.19` (symfony-nextjs; static-site nextjs-static; saas-dashboard nextjs stack).
- New guard verified by negative control (reintroducing the old pin fails the test).
- Full pytest suite: 328 passed.

Refs: agent-tasks 914d1a2c