### PR TITLE
fix(nextjs-frontend): gate test-runner config per strategy, drop JS-path orphans

### DIFF
--- a/src/scaffoldkit/blueprints/nextjs-frontend/blueprint.yaml
+++ b/src/scaffoldkit/blueprints/nextjs-frontend/blueprint.yaml
@@ -181,6 +181,7 @@ templates:
 
   - source: src/app/globals.css.j2
     target: src/app/globals.css
+    condition: is_typescript
 
   - source: src/components/features/WelcomeCard.tsx.j2
     target: src/components/features/WelcomeCard.tsx
@@ -193,19 +194,28 @@ templates:
 
   - source: postcss.config.mjs.j2
     target: postcss.config.mjs
+    condition: is_typescript
 
-  # --- Smoke test + runner config (vitest is the default runner) ---
+  # --- Smoke test + runner config (gated per chosen runner) ---
   - source: src/app/page.test.tsx.j2
     target: src/app/page.test.tsx
     condition: is_typescript
 
   - source: vitest.config.ts.j2
     target: vitest.config.ts
-    condition: is_typescript
+    condition: is_typescript_vitest
 
   - source: vitest.setup.ts.j2
     target: vitest.setup.ts
-    condition: is_typescript
+    condition: is_typescript_vitest
+
+  - source: jest.config.mjs.j2
+    target: jest.config.mjs
+    condition: is_typescript_jest
+
+  - source: jest.setup.ts.j2
+    target: jest.setup.ts
+    condition: is_typescript_jest
 
   - source: .dockerignore.j2
     target: .dockerignore

--- a/src/scaffoldkit/blueprints/nextjs-frontend/templates/jest.config.mjs.j2
+++ b/src/scaffoldkit/blueprints/nextjs-frontend/templates/jest.config.mjs.j2
@@ -1,0 +1,14 @@
+import nextJest from "next/jest.js";
+
+const createJestConfig = nextJest({ dir: "./" });
+
+/** @type {import('jest').Config} */
+const config = {
+  testEnvironment: "jest-environment-jsdom",
+  setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
+  moduleNameMapper: {
+    "^@/(.*)$": "<rootDir>/src/$1",
+  },
+};
+
+export default createJestConfig(config);

--- a/src/scaffoldkit/blueprints/nextjs-frontend/templates/jest.setup.ts.j2
+++ b/src/scaffoldkit/blueprints/nextjs-frontend/templates/jest.setup.ts.j2
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";

--- a/src/scaffoldkit/generator.py
+++ b/src/scaffoldkit/generator.py
@@ -93,6 +93,13 @@ def build_template_context(blueprint: Blueprint, variables: dict[str, Any]) -> d
     ctx["is_astro_blog"] = ctx["is_astro"] and site_type == "blog"
     ctx["is_astro_portfolio"] = ctx["is_astro"] and site_type == "portfolio"
     ctx["is_astro_landing_page"] = ctx["is_astro"] and site_type == "landing-page"
+    # nextjs-frontend test-runner discriminators: the blueprint's single-variable
+    # conditions can't express "typescript AND uses vitest", so derive the combos.
+    test_strategy = str(variables.get("test_strategy", "")).lower()
+    ctx["is_vitest"] = test_strategy in ("vitest-only", "vitest-and-playwright")
+    ctx["is_jest"] = test_strategy == "jest-and-cypress"
+    ctx["is_typescript_vitest"] = ctx["is_typescript"] and ctx["is_vitest"]
+    ctx["is_typescript_jest"] = ctx["is_typescript"] and ctx["is_jest"]
     ctx.update(blueprint.metadata)
     return ctx
 

--- a/tests/test_nextjs_frontend_starter.py
+++ b/tests/test_nextjs_frontend_starter.py
@@ -118,3 +118,45 @@ class TestNextjsFrontendStarter:
         assert "jsdom" in dev
         assert "@vitejs/plugin-react" in dev
         assert "tailwindcss" in dev
+
+    def test_jest_strategy_emits_jest_config_not_vitest(self, tmp_path: Path):
+        # Regression: vitest.config/setup were gated on is_typescript only, so the
+        # jest-and-cypress combo shipped vitest config with a jest-wired test
+        # script and no jest config — npm test failed out of the box.
+        output = _generate(tmp_path, {**_DEFAULTS, "test_strategy": "jest-and-cypress"})
+
+        jest_config = output / "jest.config.mjs"
+        jest_setup = output / "jest.setup.ts"
+        for f in (jest_config, jest_setup):
+            assert f.exists(), f"expected jest scaffold missing: {f}"
+            assert f.read_text().strip(), f"jest scaffold file is empty: {f}"
+        assert "next/jest" in jest_config.read_text()
+        assert "@testing-library/jest-dom" in jest_setup.read_text()
+
+        # The vitest runner config must NOT ship for the jest strategy.
+        assert not (output / "vitest.config.ts").exists()
+        assert not (output / "vitest.setup.ts").exists()
+
+        # The package.json test script + deps must match the chosen runner.
+        pkg = json.loads((output / "package.json").read_text())
+        assert pkg["scripts"]["test"] == "jest --runInBand"
+        assert "jest" in pkg["devDependencies"]
+        assert "vitest" not in pkg["devDependencies"]
+
+        # The smoke test ships for both runners (jest provides describe/it globally).
+        assert (output / "src" / "app" / "page.test.tsx").exists()
+
+    def test_javascript_path_emits_no_orphan_style_or_test_config(self, tmp_path: Path):
+        # The runnable starter is TypeScript-only (no .jsx app templates). The JS
+        # path must not leave orphan globals.css/postcss/runner configs behind.
+        output = _generate(tmp_path, {**_DEFAULTS, "language": "javascript"})
+
+        for orphan in (
+            "src/app/globals.css",
+            "postcss.config.mjs",
+            "vitest.config.ts",
+            "vitest.setup.ts",
+            "jest.config.mjs",
+            "jest.setup.ts",
+        ):
+            assert not (output / orphan).exists(), f"orphan emitted on JS path: {orphan}"


### PR DESCRIPTION
## What

Two non-default-combo gaps from the `nextjs-frontend` starter PR (#54) review.

### Gap 1: jest-and-cypress shipped vitest config

`vitest.config.ts` / `vitest.setup.ts` were gated on `is_typescript` only, so the `test_strategy=jest-and-cypress` combo shipped vitest configs alongside a jest-wired `npm test` with no jest config. `npm test` failed out of the box.

### Gap 2: JS path left orphan style config

`globals.css` + `postcss.config.mjs` were emitted unconditionally, but the runnable starter is TypeScript-only (only `.tsx` app templates ship). The `language=javascript` path left those configs orphaned.

## Changes

`blueprint.yaml` conditions are single-variable-truthy, so the combos are derived in `build_template_context`: `is_vitest` / `is_jest` and the typescript-gated `is_typescript_vitest` / `is_typescript_jest`.

- Gate `vitest.config`/`setup` on `is_typescript_vitest`.
- Add `jest.config.mjs` + `jest.setup.ts` (via `next/jest`, no extra deps) gated on `is_typescript_jest`.
- Gate `globals.css` + `postcss.config.mjs` on `is_typescript`, matching every other app file, so the JS path emits no orphans.
- Regression tests for both gaps.

## Verification

- Generated scaffolds run `npm test` green on both runners: `vitest-only` (2/2) and `jest-and-cypress` (2/2).
- `vitest-and-playwright` still gets vitest config; JS path emits no orphan style/runner config.
- Full pytest suite: 330 passed.

## Open decision (out of scope)

The `javascript` language choice still produces no runnable app: this blueprint ships only `.tsx` templates, so the JS path has no `page`/`layout` and its `package.json` still wires a `test` script with no test file. That is pre-existing and broader than this gating fix. Worth a separate call on whether to add `.jsx` templates or drop the `javascript` choice.

Refs: agent-tasks a6f1c75b, PHASE3_LANE_A_REPORT_2026-06-02.md