### PR TITLE
chore(nextjs-frontend): drop the unsupported javascript language choice

### DIFF
--- a/src/scaffoldkit/blueprints/nextjs-frontend/blueprint.yaml
+++ b/src/scaffoldkit/blueprints/nextjs-frontend/blueprint.yaml
@@ -49,11 +49,10 @@ variables:
     required: true
 
   - name: language
-    description: "Primary language"
+    description: "Primary language (TypeScript only; the starter ships no JS templates)"
     type: choice
     choices:
       - "typescript"
-      - "javascript"
     default: "typescript"
     required: true
 

--- a/src/scaffoldkit/blueprints/nextjs-frontend/templates/.github/workflows/ci.yml.j2
+++ b/src/scaffoldkit/blueprints/nextjs-frontend/templates/.github/workflows/ci.yml.j2
@@ -46,7 +46,7 @@ jobs:
           fi
           if [ "$PM" = "pnpm" ]; then
             pnpm lint || echo "No lint script found. Skipping lint."
-            {% if language == "typescript" %}if [ -f tsconfig.json ]; then pnpm exec tsc --noEmit || true; fi{% else %}echo "No TypeScript check required."{% endif %}
+            if [ -f tsconfig.json ]; then pnpm exec tsc --noEmit || true; fi
             pnpm test || echo "No test script found. Skipping tests."
             pnpm build || echo "No build script found. Skipping build."
 {% if use_storybook %}
@@ -54,7 +54,7 @@ jobs:
 {% endif %}
           elif [ "$PM" = "yarn" ]; then
             yarn lint || echo "No lint script found. Skipping lint."
-            {% if language == "typescript" %}if [ -f tsconfig.json ]; then yarn tsc --noEmit || true; fi{% else %}echo "No TypeScript check required."{% endif %}
+            if [ -f tsconfig.json ]; then yarn tsc --noEmit || true; fi
             yarn test || echo "No test script found. Skipping tests."
             yarn build || echo "No build script found. Skipping build."
 {% if use_storybook %}
@@ -62,7 +62,7 @@ jobs:
 {% endif %}
           else
             npm run lint || echo "No lint script found. Skipping lint."
-            {% if language == "typescript" %}if [ -f tsconfig.json ]; then npx tsc --noEmit || true; fi{% else %}echo "No TypeScript check required."{% endif %}
+            if [ -f tsconfig.json ]; then npx tsc --noEmit || true; fi
             npm test || echo "No test script found. Skipping tests."
             npm run build || echo "No build script found. Skipping build."
 {% if use_storybook %}

--- a/src/scaffoldkit/blueprints/nextjs-frontend/templates/docs/adrs/0001-architecture.md.j2
+++ b/src/scaffoldkit/blueprints/nextjs-frontend/templates/docs/adrs/0001-architecture.md.j2
@@ -68,7 +68,6 @@ The Pages Router was chosen because:
 
 ## Decision 2: {{ language | title }}
 
-{% if language == "typescript" %}
 TypeScript strict mode was chosen because:
 
 - Catch type errors at compile time, not in production
@@ -77,11 +76,6 @@ TypeScript strict mode was chosen because:
 - Required for `shadcn/ui`, TanStack Query, and other key libraries
 
 `tsconfig.json` uses `"strict": true`. Disable rules sparingly with `// @ts-expect-error` and a comment explaining why.
-{% else %}
-JavaScript was chosen to reduce initial friction. JSDoc annotations are used for type hints where it matters.
-
-**Recommendation:** Plan a TypeScript migration. The project structure and component conventions are compatible with TypeScript adoption at any time.
-{% endif %}
 
 ---
 

--- a/src/scaffoldkit/blueprints/nextjs-frontend/templates/package.json.j2
+++ b/src/scaffoldkit/blueprints/nextjs-frontend/templates/package.json.j2
@@ -7,9 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-{% if language == "typescript" -%}
     "type-check": "tsc --noEmit",
-{% endif -%}
 {% if test_strategy == "vitest-only" or test_strategy == "vitest-and-playwright" -%}
     "test": "vitest run",
 {% else -%}
@@ -55,9 +53,7 @@
     "postcss": "^8.5.3",
     "tailwindcss": "^3.4.17",
 {% endif -%}
-{% if language == "typescript" -%}
     "typescript": "^5.8.2",
-{% endif -%}
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",
 {% if test_strategy == "vitest-only" or test_strategy == "vitest-and-playwright" -%}

--- a/src/scaffoldkit/blueprints/nextjs-frontend/templates/src/app/layout.tsx.j2
+++ b/src/scaffoldkit/blueprints/nextjs-frontend/templates/src/app/layout.tsx.j2
@@ -1,5 +1,5 @@
 {% if styling == "tailwind" or styling == "scss" %}import "./globals.css";
-{% endif %}{% if language == "typescript" %}import type { Metadata } from "next";
+{% endif %}import type { Metadata } from "next";
 import type { ReactNode } from "react";
 
 export const metadata: Metadata = {
@@ -14,16 +14,3 @@ export default function RootLayout({ children }: { children: ReactNode }) {
     </html>
   );
 }
-{% else %}export const metadata = {
-  title: "{{ display_name }}",
-  description: "{{ description }}",
-};
-
-export default function RootLayout({ children }) {
-  return (
-    <html lang="en">
-      <body>{children}</body>
-    </html>
-  );
-}
-{% endif %}

--- a/src/scaffoldkit/blueprints/nextjs-frontend/templates/src/components/features/WelcomeCard.tsx.j2
+++ b/src/scaffoldkit/blueprints/nextjs-frontend/templates/src/components/features/WelcomeCard.tsx.j2
@@ -1,10 +1,9 @@
-{% if language == "typescript" %}interface WelcomeCardProps {
+interface WelcomeCardProps {
   projectName: string;
 }
 
 export function WelcomeCard({ projectName }: WelcomeCardProps) {
-{% else %}export function WelcomeCard({ projectName }) {
-{% endif %}  return (
+  return (
     <section{% if styling == "tailwind" %} className="rounded-lg border bg-card p-6 shadow-sm"{% endif %}>
       <h2{% if styling == "tailwind" %} className="text-xl font-medium"{% endif %}>Welcome to {projectName}</h2>
       <p{% if styling == "tailwind" %} className="mt-2 text-sm text-muted-foreground"{% endif %}>

--- a/tests/test_nextjs_frontend_starter.py
+++ b/tests/test_nextjs_frontend_starter.py
@@ -146,17 +146,21 @@ class TestNextjsFrontendStarter:
         # The smoke test ships for both runners (jest provides describe/it globally).
         assert (output / "src" / "app" / "page.test.tsx").exists()
 
-    def test_javascript_path_emits_no_orphan_style_or_test_config(self, tmp_path: Path):
-        # The runnable starter is TypeScript-only (no .jsx app templates). The JS
-        # path must not leave orphan globals.css/postcss/runner configs behind.
-        output = _generate(tmp_path, {**_DEFAULTS, "language": "javascript"})
+    def test_javascript_language_choice_is_not_offered(self, tmp_path: Path):
+        # The runnable starter ships only .tsx templates, so the javascript
+        # choice produced no runnable app and was dropped. The blueprint must
+        # advertise typescript as the sole language and reject javascript.
+        bp = load_blueprint(BLUEPRINTS_DIR / "nextjs-frontend")
+        language_var = next(v for v in bp.variables if v.name == "language")
+        assert language_var.choices == ["typescript"]
 
-        for orphan in (
-            "src/app/globals.css",
-            "postcss.config.mjs",
-            "vitest.config.ts",
-            "vitest.setup.ts",
-            "jest.config.mjs",
-            "jest.setup.ts",
-        ):
-            assert not (output / orphan).exists(), f"orphan emitted on JS path: {orphan}"
+        result = generate(
+            GenerationContext(
+                blueprint=bp,
+                blueprint_path=BLUEPRINTS_DIR / "nextjs-frontend",
+                variables={**_DEFAULTS, "language": "javascript"},
+                target_dir=tmp_path / "js",
+            )
+        )
+        assert not result.success
+        assert any("language" in e and "javascript" in e for e in result.errors)


### PR DESCRIPTION
## What

The `nextjs-frontend` blueprint ships only `.tsx` app templates, so `language=javascript` produced no runnable app. Per the PR #65 decision, drop the `javascript` choice rather than add `.jsx` templates.

## Changes

- Remove `javascript` from the `language` variable choices, leaving `typescript` as the sole choice.
- Resolve the now-dead JS `{% if language == "typescript" %}...{% else %}...{% endif %}` conditionals in `layout.tsx.j2`, `WelcomeCard.tsx.j2`, `ci.yml.j2`, `package.json.j2`, and the architecture ADR.
- Update the test: assert the `language` choice is typescript-only and that `language=javascript` is rejected by validation.

The `language` variable is retained (single `typescript` choice): it still drives the `is_typescript` file-emission gating and is interpolated as `{{ language | title }}` in the docs, and it leaves room to reintroduce a JS path with real templates later.

## Bonus: fixes two latent whitespace bugs

Resolving the inline `language` conditionals also fixes whitespace they corrupted on the default TypeScript path (via `lstrip_blocks`):

- **ci.yml**: the `tsc --noEmit` check rendered dedented to column 0 and merged onto the same line as the following test command (`...fi            pnpm test`), which broke the YAML block scalar (the generated workflow did not parse). It now sits on its own properly indented line.
- **package.json**: `"type-check"` and `"@testing-library/jest-dom"` rendered with no leading indentation; now indented like every other key.

## Verification

- Validation rejects `language=javascript`.
- The generated TypeScript default still runs `npm test` green (2/2).
- The only generated-output changes vs the prior templates are the two whitespace fixes above (`layout.tsx`, `WelcomeCard.tsx`, and the ADR render byte-identical).
- Full pytest suite: 330 passed.

## Noted (out of scope)

`package.json.j2` has broader pre-existing mis-indentation from other conditional blocks (test_strategy / styling / api_client): several keys render at column 0 and the `next-auth` entry glues the closing brace on. These are cosmetic (the JSON stays valid and this blueprint ships no `format:check`) and come from unrelated conditionals, so they are left out of this focused change.

Refs: agent-tasks eb9e489f