### PR TITLE
chore(release): v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-06-09
+
+Patch release fixing the generated blueprints: the Next.js templates shipped a version exposed to CVE-2025-66478, and the nextjs-frontend blueprint had test-runner and language-choice rough edges.
+
+### Fixed
+
+- **Next.js bumped off CVE-2025-66478 in the shipped blueprints** (PRs #64, #63). The `saas-dashboard`, `static-site`, `symfony-nextjs`, and `nextjs-fullstack` blueprints generated a `package.json` pinning a vulnerable Next.js; the templates now pin a patched version, so newly scaffolded projects are not born with the CVE. A blueprint-contract audit test guards the pins.
+- **`nextjs-frontend` test-runner config is gated per strategy** (PR #65), dropping the orphaned JavaScript-path config that a TypeScript scaffold left behind.
+- **`nextjs-fullstack` scaffold output is prettier-clean** (PR #63), so a freshly generated project passes its own formatter.
+
+### Changed
+
+- **Dropped the unsupported JavaScript language choice from the `nextjs-frontend` blueprint** (PR #66); the blueprint is TypeScript-only.
+
 ## [0.4.0] - 2026-06-02
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scaffoldkit"
-version = "0.4.0"
+version = "0.4.1"
 description = "AI-aided project scaffolding tool with declarative blueprints"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
# Release v0.4.1

Patch release fixing the generated blueprints. scaffoldkit is a Python CLI; the `v0.4.1` tag verifies the pyproject version, builds the distribution, and creates a GitHub Release (no PyPI publish).

## Changes since v0.4.0

| PR | Kind | Summary |
|----|------|---------|
| #64, #63 | **Security** | Next.js bumped off CVE-2025-66478 (`15.2.4` -> `15.5.19`) in the `saas-dashboard`, `static-site`, `symfony-nextjs`, and `nextjs-fullstack` blueprints, so newly scaffolded projects are not born with the CVE. A blueprint-contract audit test guards the pins. |
| #65 | fix | `nextjs-frontend` test-runner config is gated per strategy, dropping the JS-path orphans a TypeScript scaffold left behind. |
| #63 | fix | `nextjs-fullstack` scaffold output is prettier-clean. |
| #66 | chore | Dropped the unsupported JavaScript language choice from `nextjs-frontend` (TypeScript-only). |

## Test plan

- [x] Full suite green: `uv run pytest` -> 330 passed.
- [x] **CVE fix verified**: `tests/test_blueprint_contract_audit.py` (4 passed) asserts no `package.json.j2` pins the vulnerable `15.2.4`; the four blueprint templates now pin `15.5.19`.
- [x] Scope: diff is CHANGELOG + pyproject.toml (version `0.4.0` -> `0.4.1`); the release.yml gate requires the tag to match the pyproject version.
- [x] Release notes: ran the `release.yml` extraction awk for `0.4.1`; clean body, stops at `## [0.4.0]`.

## Operator action

None. Re-scaffold or bump Next.js in any project generated from these blueprints at v0.4.0 or earlier.

Refs: #63, #64, #65, #66
