### PR TITLE
docs: fix README/docs drift vs code in scaffoldkit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,7 +133,8 @@ A `Dockerfile` and `docker-compose.yml` are shipped for the Docker path.
 - Single-user local execution; no concurrency guards.
 - Blueprint variables are flat (no nested objects).
 
-[Unreleased]: https://github.com/LanNguyenSi/scaffoldkit/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/LanNguyenSi/scaffoldkit/compare/v0.4.1...HEAD
+[0.4.1]: https://github.com/LanNguyenSi/scaffoldkit/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/LanNguyenSi/scaffoldkit/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/LanNguyenSi/scaffoldkit/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/LanNguyenSi/scaffoldkit/compare/v0.1.0...v0.2.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,11 +56,16 @@ src/scaffoldkit/
   renderer.py         # Jinja2 template rendering
   models.py           # Pydantic data models
   validators.py       # Input validation
+  variable_conditions.py # Conditional-variable pruning
   filesystem.py       # File system operations
+  planforge.py        # agent-planforge export schema and variable mapping
+  scaffold_blueprint.py # init-blueprint starter generator
 
 blueprints/           # Built-in blueprint definitions
 tests/                # Test suite
 ```
+
+See [docs/architecture.md](docs/architecture.md#module-map) for the full module map.
 
 ## Adding a New Blueprint
 
@@ -82,7 +87,7 @@ tests/                # Test suite
 
 ## Pull Request Process
 
-1. Fork the repository and create a feature branch from `main`.
+1. Fork the repository and create a feature branch from `master`.
 2. Make your changes with clear, focused commits.
 3. Add or update tests for your changes.
 4. Run the full test suite and ensure it passes.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Don't want Python on your host? Use `./install.sh --docker` instead. See [docs/c
 ```
 Generation completed successfully!
 
-Files created (9):
+Files created (15):
   README.md
   pyproject.toml
   .github/workflows/ci.yml
@@ -35,6 +35,12 @@ Files created (9):
   docs/ways-of-working.md
   docs/adrs/0001-architecture.md
   AI_CONTEXT.md
+  src/__init__.py
+  src/main.py
+  src/commands/__init__.py
+  src/commands/run.py
+  tests/__init__.py
+  tests/test_run.py
   .editorconfig
   .gitignore
 
@@ -83,7 +89,7 @@ ruff format src/ tests/                             # format
 mypy src/scaffoldkit/                               # type check
 ```
 
-CI runs lint, mypy strict, pytest on Python 3.11/3.12/3.13, and a build+install verification on every push and PR to `main`.
+CI runs lint, mypy strict, pytest on Python 3.11/3.12/3.13, and a build+install verification on every push and PR to `master`.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, coding standards, and PR process. Release history lives in [CHANGELOG.md](CHANGELOG.md).
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,6 +56,10 @@ A `scaffoldkit new` invocation runs the same pipeline whether the variables come
 
 There isn't one. Generation is a one-shot operation. There is no daemon, no incremental rebuild, and no shared state between runs. Re-running into the same target directory requires `--overwrite`.
 
+## Path containment
+
+Rendered target paths come from untrusted sources (user `--var` input and third-party blueprints), so every generated file and directory is routed through `generator._safe_join`. It resolves the rendered path against the target directory and raises if the result escapes it, refusing absolute paths and `..` traversal. An unsafe entry is recorded as a generation error and skipped rather than written outside the target tree. This containment makes running a blueprint from an untrusted source safe by construction.
+
 ## Design principles
 
 - **Declarative over hard-coded.** Blueprints are YAML, templates are Jinja2. Adding a stack is adding a folder, not editing the engine.
@@ -98,8 +102,8 @@ scaffoldkit/
 │       ├── variable_conditions.py
 │       ├── planforge.py
 │       ├── scaffold_blueprint.py
-│       └── blueprints/        # 13 shipped blueprints
-├── tests/                     # 78 tests: models, loader, validators, renderer, filesystem, generator, CLI, integration
+│       └── blueprints/        # 12 shipped blueprints
+├── tests/                     # pytest suite: models, loader, validators, renderer, filesystem, generator, CLI, integration
 ├── .github/workflows/ci.yml   # lint, mypy strict, pytest 3.11/3.12/3.13, build+install
 ├── CONTRIBUTING.md
 ├── CHANGELOG.md
@@ -108,7 +112,7 @@ scaffoldkit/
 
 ## Test suite
 
-78 tests cover:
+The pytest suite covers:
 
 - **Models.** Data model construction and validation.
 - **Blueprint loading.** Discovery, parsing, error handling.
@@ -119,7 +123,7 @@ scaffoldkit/
 - **CLI.** Command help, blueprint listing, error paths.
 - **Integration.** End-to-end generation across stack/style/feature variations.
 
-CI runs ruff lint+format, mypy strict, pytest on Python 3.11, 3.12, 3.13, and a build+install verification on every push and PR to `main`.
+CI runs ruff lint+format, mypy strict, pytest on Python 3.11, 3.12, 3.13, and a build+install verification on every push and PR to `master`.
 
 ## Assumptions and limits
 

--- a/docs/blueprints.md
+++ b/docs/blueprints.md
@@ -20,6 +20,9 @@ description: "What this blueprint generates"
 version: "1.0.0"
 stack: "nextjs"
 
+metadata:                 # Optional: free-form keys merged into the template context
+  architecture: "layered"
+
 variables:
   - name: project_name
     description: "Project slug"
@@ -72,6 +75,8 @@ Authentication is enabled.
 ```
 
 The generator also injects derived flags (`is_python`, `is_typescript`, `is_fastapi`, `is_nextjs_fullstack`, `is_uv`, `is_yaml_config`, etc.) so templates can branch on language/framework/package-manager without re-implementing string compares. See [architecture.md](architecture.md) for the full list.
+
+Any keys under the blueprint's top-level `metadata` map are also merged into the template context verbatim, so blueprint authors can expose extra template variables (for example an `architecture` label) without adding a user-facing prompt.
 
 ## Shipped blueprints
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -81,6 +81,15 @@ source .venv/bin/activate
 uv pip install -e ".[dev]"
 ```
 
+## Global options
+
+These apply to the top-level `scaffoldkit` command itself, before any subcommand.
+
+| Option | Description |
+|--------|-------------|
+| `-V, --version` | Print the installed ScaffoldKit version and exit. The version is read from package metadata, so it always matches the installed distribution. |
+| `--help` | Show help. With no subcommand, `scaffoldkit` prints help by default. |
+
 ## `scaffoldkit new`
 
 Generate a project from a blueprint.
@@ -155,7 +164,7 @@ scaffoldkit from-planforge ./scaffoldkit-input.json --target ./my-project
 
 Selects the recommended blueprint (with fallback resolution), maps planforge `suggestedVariables` onto the blueprint contract, and applies a small set of inference rules for things like `database`, `auth_strategy`, and `use_docker`. See [planforge-integration.md](planforge-integration.md) for the full schema and inference rules.
 
-Same `--target`, `--dry-run`, `--overwrite`, `--no-install`, `--blueprints-dir` flags as `new`.
+Same `--target`, `--dry-run`, `--overwrite`, `--no-install`, `--blueprints-dir` flags as `new`, plus a `from-planforge`-only `--no-ai-context` flag that suppresses the blueprint's AI-context files (the `.ai/` tree and `AI_CONTEXT.md`) for callers that already provide their own agent context.
 
 ## `scaffoldkit init-blueprint`
 

--- a/docs/planforge-integration.md
+++ b/docs/planforge-integration.md
@@ -8,7 +8,7 @@
 scaffoldkit from-planforge ./scaffoldkit-input.json --target ./my-project
 ```
 
-Same flags as `scaffoldkit new` except for `--var` / `--non-interactive` / `--yes`: planforge supplies those values. The supported flags are `--target`, `--dry-run`, `--overwrite`, `--no-install`, `--blueprints-dir`.
+Same flags as `scaffoldkit new` except for `--var` / `--non-interactive` / `--yes`: planforge supplies those values. The supported flags are `--target`, `--dry-run`, `--overwrite`, `--no-install`, `--blueprints-dir`, and `--no-ai-context`. The last is specific to `from-planforge`: it suppresses the blueprint's AI-context files (the `.ai/` tree and `AI_CONTEXT.md`), which is useful when the caller already owns its own agent context, e.g. the agent-planforge container whose `.ai/` would otherwise be clobbered by `--overwrite`.
 
 If the planforge-recommended blueprint isn't installed locally, the resolver walks `blueprintCandidates` in order and falls back to the first match, printing which fallback it picked. If none match, you get the candidate list plus the locally available blueprints in the error output.
 


### PR DESCRIPTION
Fixes 7 verified documentation-vs-code drifts (plus in-repo sibling instances) from an org-wide README/docs audit. Each finding independently verified against source; branch reviewed by a separate reviewer subagent (verdict: APPROVE).

Scope: docs follow code (no features invented; non-existent commands/features removed or marked Planned; phantom Makefile targets corrected; version/identity constants aligned where code was the stale outlier). Sibling copies across secondary docs, UI strings, and code comments also fixed.

Refs: DOCS_DRIFT_REPORT_2026-06-18