### PR TITLE
fix(deps): raise jinja2/pydantic floors to non-vulnerable minimums

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,9 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "jinja2>=3.1",
+    "jinja2>=3.1.6",
     "pyyaml>=6.0",
-    "pydantic>=2.0",
+    "pydantic>=2.4.0",
     "questionary>=2.0",
     "rich>=13.0",
     "typer>=0.9",


### PR DESCRIPTION
## What
Raise the declared pyproject floors for `jinja2` (`>=3.1` to `>=3.1.6`) and `pydantic` (`>=2.0` to `>=2.4.0`) to versions at or above their published security fixes.

## Why
scaffoldkit intentionally does not commit a lockfile (uv.lock is gitignored, CI resolves fresh via `uv sync`), so the declared floor is the only security signal a scanner or a consumer pinning the lower bound has. The old floors allowed versions vulnerable to 5 jinja2 advisories (fixed by 3.1.6) and a pydantic ReDoS (CVE-2024-3772, fixed 2.4.0). depsight flagged these 6.

## Verification
- `uv lock` resolves cleanly (34 packages); resolved versions are unchanged (jinja2 3.1.6, pydantic 2.13.4), both at or above the new floors, so install behaviour does not change.
- All 330 tests pass.
- After merge plus depsight rescan: scaffoldkit drops from 6 to 0 CVEs.

Refs: agent-tasks 02081140