### PR TITLE
test(coverage): close 4 audit gaps (npm-install, variable_conditions, planforge) + CI coverage gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
         run: uv sync --python ${{ matrix.python-version }} --extra dev
 
       - name: Run tests
-        run: uv run pytest tests/ -v --tb=short
+        run: uv run pytest tests/ -v --tb=short --cov=src/scaffoldkit --cov-report=term-missing --cov-fail-under=83
 
   build:
     name: Build Package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,10 @@ select = [
 "src/scaffoldkit/models.py" = ["TCH003"]  # Pydantic needs Path at runtime
 "src/scaffoldkit/cli.py" = ["TCH003"]    # Typer evaluates annotations at runtime
 
+[tool.coverage.run]
+source = ["src/scaffoldkit"]
+omit = ["src/scaffoldkit/blueprints/**"]
+
 [tool.mypy]
 python_version = "3.11"
 strict = true

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 """Tests for CLI commands."""
 
 import json
+import subprocess
 from importlib.metadata import version
 
 from typer.testing import CliRunner
@@ -417,3 +418,98 @@ class TestFromPlanforgeCommand:
         assert result.exit_code == 1
         assert "No compatible blueprint" in result.output
         assert "missing-blueprint" in result.output
+
+
+_NPM_INSTALL_VARS = [
+    "--var",
+    "project_name=npm-test",
+    "--var",
+    "display_name=Npm Test",
+    "--var",
+    "description=npm install test",
+    "--var",
+    "language=typescript",
+    "--var",
+    "cli_framework=commander",
+    "--var",
+    "distribution=binary",
+    "--var",
+    "ai_context=false",
+]
+
+
+class TestNpmInstall:
+    def test_success_calls_npm_install(self, tmp_path, monkeypatch):
+        calls = []
+
+        def fake_run(*args, **kwargs):
+            calls.append((args, kwargs))
+
+        monkeypatch.setattr("scaffoldkit.cli.subprocess.run", fake_run)
+
+        target = tmp_path / "npm-success"
+        result = runner.invoke(
+            app,
+            [
+                "new",
+                "cli-tool",
+                "--target",
+                str(target),
+                "--non-interactive",
+                "--yes",
+                *_NPM_INSTALL_VARS,
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert len(calls) == 1
+        call_args, call_kwargs = calls[0]
+        assert call_args[0] == ["npm", "install"]
+        assert call_kwargs["cwd"] == target
+        assert call_kwargs["check"] is True
+
+    def test_called_process_error_is_swallowed(self, tmp_path, monkeypatch):
+        def fake_run(*args, **kwargs):
+            raise subprocess.CalledProcessError(returncode=1, cmd=["npm", "install"])
+
+        monkeypatch.setattr("scaffoldkit.cli.subprocess.run", fake_run)
+
+        target = tmp_path / "npm-cpe"
+        result = runner.invoke(
+            app,
+            [
+                "new",
+                "cli-tool",
+                "--target",
+                str(target),
+                "--non-interactive",
+                "--yes",
+                *_NPM_INSTALL_VARS,
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "npm install failed with exit code 1" in result.output
+
+    def test_file_not_found_is_swallowed(self, tmp_path, monkeypatch):
+        def fake_run(*args, **kwargs):
+            raise FileNotFoundError
+
+        monkeypatch.setattr("scaffoldkit.cli.subprocess.run", fake_run)
+
+        target = tmp_path / "npm-fnf"
+        result = runner.invoke(
+            app,
+            [
+                "new",
+                "cli-tool",
+                "--target",
+                str(target),
+                "--non-interactive",
+                "--yes",
+                *_NPM_INSTALL_VARS,
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "npm not found" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -440,6 +440,10 @@ _NPM_INSTALL_VARS = [
 
 class TestNpmInstall:
     def test_success_calls_npm_install(self, tmp_path, monkeypatch):
+        # _run_npm_install only runs when the generated target contains a
+        # package.json (the cli.py gate). The cli-tool blueprint with
+        # language=typescript emits one, so omitting --no-install reaches the
+        # subprocess call below.
         calls = []
 
         def fake_run(*args, **kwargs):
@@ -462,11 +466,14 @@ class TestNpmInstall:
         )
 
         assert result.exit_code == 0, result.output
+        assert (target / "package.json").exists()  # precondition for the npm gate
         assert len(calls) == 1
         call_args, call_kwargs = calls[0]
         assert call_args[0] == ["npm", "install"]
         assert call_kwargs["cwd"] == target
         assert call_kwargs["check"] is True
+        assert call_kwargs["capture_output"] is False
+        assert "npm install completed" in result.output
 
     def test_called_process_error_is_swallowed(self, tmp_path, monkeypatch):
         def fake_run(*args, **kwargs):

--- a/tests/test_planforge.py
+++ b/tests/test_planforge.py
@@ -1,0 +1,116 @@
+"""Tests for planforge.py — load_planforge_export, default_target_name, infer_* helpers."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scaffoldkit.planforge import (
+    PlanforgeExport,
+    default_target_name,
+    infer_auth_strategy,
+    infer_database_choice,
+    load_planforge_export,
+)
+
+
+def _minimal_export(**kwargs) -> PlanforgeExport:
+    """Return a PlanforgeExport with only the required fields plus any overrides."""
+    base = {"projectName": "Test Project", "blueprint": "rest-api"}
+    base.update(kwargs)
+    return PlanforgeExport.model_validate(base)
+
+
+class TestLoadPlanforgeExport:
+    def test_file_not_found_raises_value_error(self, tmp_path: Path):
+        missing = tmp_path / "does-not-exist.json"
+        with pytest.raises(ValueError, match="not found"):
+            load_planforge_export(missing)
+
+    def test_invalid_json_raises_value_error(self, tmp_path: Path):
+        bad_json = tmp_path / "bad.json"
+        bad_json.write_text("this is not json", encoding="utf-8")
+        with pytest.raises(ValueError, match="Invalid JSON"):
+            load_planforge_export(bad_json)
+
+    def test_missing_required_fields_raises_value_error(self, tmp_path: Path):
+        # Valid JSON but missing projectName and blueprint (both required by PlanforgeExport)
+        incomplete = tmp_path / "incomplete.json"
+        incomplete.write_text(json.dumps({"summary": "no required fields"}), encoding="utf-8")
+        with pytest.raises(ValueError, match="Invalid planforge export"):
+            load_planforge_export(incomplete)
+
+    def test_valid_export_loads_correctly(self, tmp_path: Path):
+        payload = {"projectName": "My App", "blueprint": "rest-api", "summary": "A test app"}
+        export_file = tmp_path / "scaffoldkit-input.json"
+        export_file.write_text(json.dumps(payload), encoding="utf-8")
+        result = load_planforge_export(export_file)
+        assert result.projectName == "My App"
+        assert result.blueprint == "rest-api"
+
+
+class TestDefaultTargetName:
+    def test_normal_project_name_slugified(self):
+        export = _minimal_export(projectName="My Cool App")
+        assert default_target_name(export) == "my-cool-app"
+
+    def test_empty_project_name_returns_fallback(self):
+        export = _minimal_export(projectName="")
+        assert default_target_name(export) == "generated-project"
+
+    def test_whitespace_only_project_name_returns_fallback(self):
+        export = _minimal_export(projectName="   ")
+        assert default_target_name(export) == "generated-project"
+
+    def test_special_chars_are_slugified(self):
+        export = _minimal_export(projectName="Hello World 2024!")
+        assert default_target_name(export) == "hello-world-2024"
+
+
+class TestInferDatabaseChoice:
+    def test_sqlite_signal_in_constraints(self):
+        export = _minimal_export(constraints=["prefer sqlite for local dev"])
+        assert infer_database_choice(export, "db_provider") == "sqlite"
+
+    def test_mysql_signal_in_constraints(self):
+        export = _minimal_export(constraints=["must use mysql 8"])
+        assert infer_database_choice(export, "db_provider") == "mysql"
+
+    def test_mongodb_signal_with_database_variable(self):
+        export = _minimal_export(stack={"dataStore": "mongodb"})
+        assert infer_database_choice(export, "database") == "mongodb"
+
+    def test_mongodb_signal_ignored_for_non_database_variable(self):
+        # "mongo" in text but variable_name != "database" — falls through to postgresql
+        export = _minimal_export(stack={"dataStore": "mongodb"})
+        assert infer_database_choice(export, "db_provider") == "postgresql"
+
+    def test_no_signal_defaults_to_postgresql(self):
+        export = _minimal_export()
+        assert infer_database_choice(export, "db_provider") == "postgresql"
+
+
+class TestInferAuthStrategy:
+    def test_public_only_signal_returns_none(self):
+        export = _minimal_export(constraints=["public-only, no login required"])
+        assert infer_auth_strategy(export, "rest-api") == "none"
+
+    def test_anonymous_signal_returns_none(self):
+        export = _minimal_export(summary="anonymous read-only API")
+        assert infer_auth_strategy(export, "rest-api") == "none"
+
+    def test_api_key_signal_returns_api_key_for_non_django(self):
+        export = _minimal_export(features=["api-key authentication"])
+        assert infer_auth_strategy(export, "rest-api") == "api-key"
+
+    def test_api_key_signal_returns_token_for_django_drf(self):
+        export = _minimal_export(features=["api-key authentication"])
+        assert infer_auth_strategy(export, "django-drf") == "token"
+
+    def test_oauth2_signal_returns_oauth2(self):
+        export = _minimal_export(features=["oauth2 social login"])
+        assert infer_auth_strategy(export, "rest-api") == "oauth2"
+
+    def test_no_signal_defaults_to_jwt(self):
+        export = _minimal_export()
+        assert infer_auth_strategy(export, "rest-api") == "jwt"

--- a/tests/test_variable_conditions.py
+++ b/tests/test_variable_conditions.py
@@ -1,0 +1,113 @@
+"""Tests for variable_conditions pure-function helpers."""
+
+import pytest
+
+from scaffoldkit.models import Blueprint, BlueprintVariable
+from scaffoldkit.variable_conditions import (
+    _is_truthy,
+    prune_inactive_variables,
+    variable_is_active,
+)
+
+
+def _var(name: str, *, condition: str | None = None, default=None) -> BlueprintVariable:
+    return BlueprintVariable(name=name, condition=condition, default=default)
+
+
+class TestIsTruthy:
+    @pytest.mark.parametrize("value", [True, 1, "true", "True", "TRUE", "yes", "YES", "1", "on"])
+    def test_truthy_values(self, value):
+        assert _is_truthy(value) is True
+
+    @pytest.mark.parametrize("value", ["false", "no", "0", "off", ""])
+    def test_false_strings(self, value):
+        assert _is_truthy(value) is False
+
+    def test_false_bool(self):
+        assert _is_truthy(False) is False
+
+    def test_none_is_falsy(self):
+        assert _is_truthy(None) is False
+
+    def test_zero_int_is_falsy(self):
+        assert _is_truthy(0) is False
+
+    def test_nonempty_string_is_truthy(self):
+        assert _is_truthy("hello") is True
+
+
+class TestVariableIsActive:
+    def test_no_condition_always_active(self):
+        var = _var("x")
+        assert variable_is_active(var, {}, {}) is True
+
+    def test_condition_in_values_truthy(self):
+        var = _var("child", condition="ctrl")
+        assert variable_is_active(var, {"ctrl": True}, {}) is True
+
+    def test_condition_in_values_falsy(self):
+        var = _var("child", condition="ctrl")
+        assert variable_is_active(var, {"ctrl": False}, {}) is False
+
+    def test_cycle_detected_returns_false(self):
+        # condition_name "a" is already in the `seen` set — cycle guard at line 25 fires
+        var = _var("b", condition="a")
+        assert variable_is_active(var, {}, {}, seen={"a"}) is False
+
+    def test_inactive_controller_makes_child_inactive(self):
+        # ctrl depends on gate; gate=False → ctrl inactive → child inactive (line 31)
+        ctrl = _var("ctrl", condition="gate")
+        child = _var("child", condition="ctrl")
+        definitions = {"ctrl": ctrl, "child": child}
+        assert variable_is_active(child, {"gate": False}, definitions) is False
+
+    def test_none_controller_returns_false(self):
+        # condition references a name absent from definitions and values (lines 36-37)
+        var = _var("child", condition="nonexistent")
+        assert variable_is_active(var, {}, {}) is False
+
+    def test_falls_back_to_controller_default_true(self):
+        # condition_name not in values; falls through to _is_truthy(controller.default) (line 39)
+        ctrl = _var("ctrl", default=True)
+        child = _var("child", condition="ctrl")
+        definitions = {"ctrl": ctrl}
+        assert variable_is_active(child, {}, definitions) is True
+
+    def test_falls_back_to_controller_default_false(self):
+        ctrl = _var("ctrl", default=False)
+        child = _var("child", condition="ctrl")
+        definitions = {"ctrl": ctrl}
+        assert variable_is_active(child, {}, definitions) is False
+
+
+class TestPruneInactiveVariables:
+    def _blueprint(self, *variables: BlueprintVariable) -> Blueprint:
+        return Blueprint(name="test", display_name="Test", variables=list(variables))
+
+    def test_drops_inactive_variable(self):
+        ctrl = _var("ctrl")
+        child = _var("child", condition="ctrl")
+        bp = self._blueprint(ctrl, child)
+        pruned = prune_inactive_variables(bp, {"ctrl": False, "child": "val"})
+        assert "child" not in pruned
+        assert "ctrl" in pruned
+
+    def test_keeps_active_variable(self):
+        ctrl = _var("ctrl")
+        child = _var("child", condition="ctrl")
+        bp = self._blueprint(ctrl, child)
+        pruned = prune_inactive_variables(bp, {"ctrl": True, "child": "val"})
+        assert "child" in pruned
+        assert pruned["child"] == "val"
+
+    def test_unconditional_variable_always_kept(self):
+        var = _var("plain")
+        bp = self._blueprint(var)
+        pruned = prune_inactive_variables(bp, {"plain": "hello"})
+        assert pruned["plain"] == "hello"
+
+    def test_missing_value_not_added_by_prune(self):
+        var = _var("x")
+        bp = self._blueprint(var)
+        pruned = prune_inactive_variables(bp, {})
+        assert "x" not in pruned


### PR DESCRIPTION
## What

Closes all 4 audit-verified test-coverage gaps in scaffoldkit (severity C0/H0/M2/L2) and adds a CI coverage gate. No production source changed.

## Gaps closed

| Gap | Sev | What |
|---|---|---|
| cli.py `_run_npm_install` | MED | success + `CalledProcessError`-swallowed + `FileNotFoundError`-swallowed, via monkeypatch of `scaffoldkit.cli.subprocess.run` (cli-tool blueprint emits package.json so the npm path is reached without `--no-install`) |
| variable_conditions.py | LOW | 30 tests: cycle detection, inactive/None controller, `controller.default` fallback, all `_is_truthy` false-strings (module 69% to 100%) |
| planforge.py | LOW | 19 tests: `load_planforge_export` missing-file / invalid-JSON / missing-fields error branches, empty-slug target fallback, `infer_database_choice` + `infer_auth_strategy` branches (86% to 92%) |
| CI coverage gate | MED | `[tool.coverage.run]` (source=src/scaffoldkit, omit blueprint templates) + `--cov --cov-fail-under=83` on the pytest step |

## Coverage

52 new tests (382 total). Source coverage 83% to **87.14%** (blueprint templates omitted; they are data/templates, not logic). `--cov-fail-under=83` is set ~4 points below measured to absorb 3.11/3.13 matrix variance. Mutation-checked: the npm error-swallow re-raise, a variable_conditions guard, and a planforge infer branch each red a test.

ruff (check + format) and mypy clean; full suite green.

Refs: tc-audit-2026-06-27
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>